### PR TITLE
make integration test combinations configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,7 @@ dataverse:
     test_suite: false
     # possible test values from https://github.com/IQSS/dataverse/blob/develop/conf/docker-aio/run-test-suite.sh#L11
     # beware DataversesIT and DatasetsIT at minimum must be run for any other tests to succeed. have fun.
+    #tests: "DataversesIT,DatasetsIT,AdminIT"
     tests: all
   branding:
     enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,9 @@ dataverse:
     blocked_policy: "localhost-only"
     location: "http://localhost:8080/api"
     test_suite: false
+    # possible test values from https://github.com/IQSS/dataverse/blob/develop/conf/docker-aio/run-test-suite.sh#L11
+    # beware DataversesIT and DatasetsIT at minimum must be run for any other tests to succeed. have fun.
+    tests: all
   branding:
     enabled: false
     directory: "{{ playbook_dir }}/files/branding"

--- a/tasks/dataverse-api-testsuite.yml
+++ b/tasks/dataverse-api-testsuite.yml
@@ -42,6 +42,13 @@
     mode: 0755
   tags: apitestsuite
 
+- name: run only specified tests
+  lineinfile:
+    path: /tmp/dataverse/run-test-suite.sh
+    regexp: '^mvn test.*'
+    line: 'mvn test -Dtest={{ dataverse.api.tests }} -Ddataverse.test.baseurl=$dvurl'
+  when: dataverse.api.tests != "all"
+
 - name: set user management quesadilla
   uri:
     url: 'http://localhost:8080/api/admin/settings/BuiltinUsers.KEY'

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -35,6 +35,7 @@ dataverse:
     test_suite: true
     # possible test values from https://github.com/IQSS/dataverse/blob/develop/conf/docker-aio/run-test-suite.sh#L11
     # beware DataversesIT and DatasetsIT at minimum must be run for any other tests to succeed. have fun.
+    #tests: "DataversesIT,DatasetsIT,AdminIT"
     tests: all
   branding:
     enabled: false

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -33,6 +33,9 @@ dataverse:
     blocked_policy: "localhost-only"
     location: "http://localhost:8080/api"
     test_suite: true
+    # possible test values from https://github.com/IQSS/dataverse/blob/develop/conf/docker-aio/run-test-suite.sh#L11
+    # beware DataversesIT and DatasetsIT at minimum must be run for any other tests to succeed. have fun.
+    tests: all
   branding:
     enabled: false
     directory: "{{ playbook_dir }}/files/branding"

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -39,6 +39,7 @@ dataverse:
     test_suite: true
     # possible test values from https://github.com/IQSS/dataverse/blob/develop/conf/docker-aio/run-test-suite.sh#L11
     # beware DataversesIT and DatasetsIT at minimum must be run for any other tests to succeed. have fun.
+    #tests: "DataversesIT,DatasetsIT,AdminIT"
     tests: all
   branding:
     enabled: false

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -2,7 +2,7 @@
 # dataverse/tests/group_vars/vagrant.yml
 
 # un-nested so we can pass them at the CLI
-dataverse_branch: release
+dataverse_branch: develop
 dataverse_repo: https://github.com/IQSS/dataverse.git
 
 apache:
@@ -37,6 +37,9 @@ dataverse:
     blocked_policy: "localhost-only"
     location: "http://localhost:8080/api"
     test_suite: true
+    # possible test values from https://github.com/IQSS/dataverse/blob/develop/conf/docker-aio/run-test-suite.sh#L11
+    # beware DataversesIT and DatasetsIT at minimum must be run for any other tests to succeed. have fun.
+    tests: all
   branding:
     enabled: false
     directory: "{{ playbook_dir }}/files/branding"


### PR DESCRIPTION
though note one may shoot oneself in the foot, as many of the integration tests depend on others earlier in the list.

Closes #13 