### PR TITLE
Replaced script-module calls with shell-module calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 venv
 .vagrant/
+/.idea
+/*.iml

--- a/tasks/custom_sampledata.yml
+++ b/tasks/custom_sampledata.yml
@@ -50,7 +50,7 @@
 # but the above find command fails outside of vagrant(?!?)
 # so let's hard-code create-users.sh for now
 - name: run scripts in sampleuser dir
-  script: '{{ dataverse.custom_sampledata.custom_sampleusers }}/create-users.sh {{ dataverse.custom_sampledata.custom_sampleusers }}'
+  shell: '{{ dataverse.custom_sampledata.custom_sampleusers }}/create-users.sh {{ dataverse.custom_sampledata.custom_sampleusers }}'
   args:
     chdir: '{{ dataverse.custom_sampledata.custom_sampleusers }}'
   
@@ -79,7 +79,7 @@
   register: sampledatasetscripts_list
 
 - name: run sampledatasets scripts
-  script: '{{ item.path }} {{ api_token }} {{ dataverse.custom_sampledata.custom_sampledatasets }}'
+  shell: '{{ item.path }} {{ api_token }} {{ dataverse.custom_sampledata.custom_sampledatasets }}'
   args:
     chdir: '{{ dataverse.custom_sampledata.custom_sampledatasets }}'
   with_items: '{{ sampledatasetscripts_list.files }}'
@@ -92,7 +92,7 @@
   register: sampledatafilescripts_list
 
 - name: run sampledatafile scripts
-  script: '{{ item.path }} {{ api_token }} {{ dataverse.custom_sampledata.custom_samplefiles }}'
+  shell: '{{ item.path }} {{ api_token }} {{ dataverse.custom_sampledata.custom_samplefiles }}'
   args:
     chdir: '{{ dataverse.custom_sampledata.custom_samplefiles }}'
   with_items: '{{ sampledatafilescripts_list.files }}'

--- a/tasks/dataverse-install.yml
+++ b/tasks/dataverse-install.yml
@@ -104,7 +104,7 @@
         dataverse.glassfish.zipurl is not match(".*glassfish-4.1.zip")
 
 - name: fire off installer
-  script: '/usr/bin/python /tmp/dvinstall/install.py -f --config_file=default.config --noninteractive > /tmp/dvinstall/install.out 2>&1'
+  shell: '/usr/bin/python /tmp/dvinstall/install.py -f --config_file=default.config --noninteractive > /tmp/dvinstall/install.out 2>&1'
   become: yes
   become_user: '{{ dataverse.glassfish.user }}'
   args:

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -58,7 +58,7 @@
   when: dataverse.custom_metadata_blocks.enabled == True
 
 - name: update custom metadata blocks
-  script: '/tmp/dvinstall/updateSchemaMDB.sh -t {{ dataverse.solr.root }}/server/solr/collection1/conf'
+  shell: '/tmp/dvinstall/updateSchemaMDB.sh -t {{ dataverse.solr.root }}/server/solr/collection1/conf'
   become: yes
   become_user: '{{ dataverse.solr.user }}'
   when: dataverse.custom_metadata_blocks.enabled == True

--- a/tasks/dataverse-previewers.yml
+++ b/tasks/dataverse-previewers.yml
@@ -4,6 +4,17 @@
   debug:
     msg: '##### DATAVERSE PREVIEWERS #####'
 
+- name: upload dataverse-previewers.sh script
+  copy:
+    src: dataverse-previewers.sh
+    dest: '{{ ansible_user_dir }}'
+    mode: 0700
+
 - name: enable dataverse-previewers
-  script: dataverse-previewers.sh
+  shell: '{{ ansible_user_dir }}/dataverse-previewers.sh'
   tags: previewers
+
+- name: clean up dataverse-previewers.sh script
+  file:
+    path: '{{ ansible_user_dir }}/dataverse-previewers.sh'
+    state: absent


### PR DESCRIPTION
Solves #18 

The Ansilbe script module compiles the script into a binary executable on the controlling machine (e.g., MacBook). If the controlling machine has a different OS than the controlled machine (e.g., Linux) this causes Ansible to try to run an executable with an incompatible binary format on the controlled machine (e.g., a Mach-O 64-bit x86_64 executable on a Linux machine) resulting in an error.

Mostly, I only had a replace the word script with the word shell. In one instance the script to be executed had to be transferred to the controlled machine first.
