### PR TITLE
add file used for memory tests

### DIFF
--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -1,0 +1,293 @@
+---
+# dataverse/defaults/main.yml
+
+# un-nested so we can pass them at the CLI
+dataverse_branch: release
+dataverse_repo: https://github.com/IQSS/dataverse.git
+
+apache:
+  ssl:
+    enabled: false
+    remote_cert: false
+    port: 443
+    cert: 
+    interm: 
+    key: 
+    pem:
+      cert: 
+      key: 
+      interm: 
+  port: 80
+  behind_reverse_proxy: false
+  behind_ssl_reverse_proxy: false
+
+letsencrypt:
+  enabled: false
+  certbot:
+    autorenew: true
+    email:
+    user: certbot
+
+dataverse:
+  adminpass: admin1
+  allow_signups: true
+  api:
+    allow_lookup: false
+    blocked_endpoints: "admin,test"
+    blocked_policy: "localhost-only"
+    location: "http://localhost:8080/api"
+    test_suite: false
+    # possible test values from https://github.com/IQSS/dataverse/blob/develop/conf/docker-aio/run-test-suite.sh#L11
+    # beware DataversesIT and DatasetsIT at minimum must be run for any other tests to succeed. have fun.
+    #tests: "DataversesIT,DatasetsIT,AdminIT"
+    tests: all
+  branding:
+    enabled: false
+    directory: "{{ playbook_dir }}/files/branding"
+    favicons_directory: "{{ playbook_dir }}/files/favicons"
+    fileSettings:
+     - setting: HeaderCustomizationFile
+       file: custom-header.html
+     - setting: StyleCustomizationFile
+       file: custom-stylesheet.css
+     - setting: LogoCustomizationFile
+       file: topbanner001w425_darkbg.png'
+    otherSettings:
+     - setting: FooterCopyright
+       value: Your institute name here
+  copyright: "Your Institution"
+  counter:
+    enabled: false
+    geoipdir: maxmind_geoip
+    geoipfile: GeoLite2-Country.mmdb
+    hub_api_token: set_me_in_secrets
+    hub_base_url: "https://api.datacite.org"
+    machines_url: "https://raw.githubusercontent.com/CDLUC3/Make-Data-Count/master/user-agents/lists/machine.txt"
+    maxmind_geoip_country_path: "maxmind_geoip/GeoLite2-Country.mmdb"
+    output_file: "/dataverse/sushi_sample_logs"
+    output_format: json
+    platform: dash
+    robots_url: "https://raw.githubusercontent.com/CDLUC3/Make-Data-Count/master/user-agents/lists/robot.txt"
+    version: "0.1"
+    upload_to_hub: False
+    user: counter
+    year_month: "2018-05"
+  custom_metadata_blocks:
+    enabled: false
+    urls:
+      - https://github.com/IQSS/dataverse/files/3744336/codemeta.tsv.txt
+  default:
+    config:
+  demo: false
+  doi:
+    authority: "10.5072"
+    baseurl: "https://mds.test.datacite.org/"
+    mdcbaseurl: "https://api.test.datacite.org/"
+    username: "testaccount"
+    password: "notmypassword"
+    protocol: doi
+    provider: FAKE
+    shoulder: "FK2/"
+  externaltools:
+    datacurationtool:
+      enabled: true
+      method: demo
+    dataexplorer:
+      enabled: true
+    wholetale:
+      enabled: false
+  ## The first item of 'filesdirs' is the default filestore
+  ## If you change the label, be prepared to change the SQL database if there are already files here
+  ## It is better practice to add a new data store and then migrate to it later
+  ## Also, changing the default storage takes effect immediately for temp files, but
+  ## only after restart for publishing (i.e. without restart the temp files will be moved to the old default data store at publish time).
+  filesdirs:
+    - label: file
+      path: /usr/local/dvn/data
+#   - label: label
+#     path: /path/to/filestore   ## this is a sample entry for further file stores
+  glassfish:
+    user: dataverse
+    group: dataverse
+    domain: domain1
+    logformat: ulf
+    adminuser: admin
+    adminpass: notPr0d
+    siteurl:
+    timeout: 180
+    request_timeout: 1800
+    root: /usr/local
+    dir: payara5
+    zipurl: https://github.com/payara/Payara/releases/download/payara-server-5.2020.2/payara-5.2020.2.zip
+    zipchecksum: sha256:1f5f7ea30901b1b4c7bcdfa5591881a700c9b7e2022ae3894192ba97eb83cc3e
+  google_analytics_key:
+  jacoco:
+    enabled: false
+    home: /tmp/jacoco
+    version: 0.8.1
+  maxfileuploadsizeinbytes:
+  memheap: 2048
+  previewers:
+    enabled: true
+  sampledata:
+    enabled: true
+    dir: /tmp/sampledata
+    repo: https://github.com/IQSS/dataverse-sample-data.git
+    branch: master
+    venv: /tmp/sampledata/venv
+  custom_sampledata:
+    enabled: false
+    custom_sampledir: "{{ playbook_dir }}/custom_sampledata"
+    custom_sampledatasets: "{{ playbook_dir }}/custom_sampledata/datasets"
+    custom_sampledataverses: "{{ playbook_dir }}/custom_sampledata/dataverses"
+    custom_sampleusers: "{{ playbook_dir }}/custom_sampledata/users"
+    custom_samplefiles: "{{ playbook_dir }}/custom_sampledata/files"
+  service_email: noreply@dataverse.yourinstitution.edu
+  smtp: localhost # or the FQDN of your organization's SMTP relay
+  solr:
+    group: solr
+    root: /usr/local/solr
+    user: solr
+    version: 7.7.2
+    checksum: sha256:eb8ee4038f25364328355de3338e46961093e39166c9bcc28b5915ae491320df
+    listen: 127.0.0.1
+  srcdir: /tmp/dataverse
+  thumbnails: true
+  unittests:
+    enabled: false
+    argument: '-DcompilerArgument=-Xlint:unchecked test -P all-unit-tests'
+  usermgmtkey: burrito
+  version: '4.20'
+
+build_guides: false
+
+db:
+  postgres:
+    adminpass: DVn33dsth1s
+    name: dvndb
+    host: localhost
+    user: dvnuser
+    pass: dvnsecret
+    jdbcurl: 
+    log_lock_waits: true
+    version: 10
+    port: 5432
+  use_rds: false
+
+grafana:
+  grafana_user: 'admin'
+  grafana_password: 'adm1n'
+
+java:
+  version: 1.8.0
+
+localstack:
+  enabled: false
+  docker:
+    cidr: 
+    repo: https://download.docker.com/linux/centos/docker-ce.repo
+  container: 's3-test'
+  # set to /tmp/localstack/data to enable persistence
+  data_dir:
+  debug: true
+  hostname_external: 
+  web_ui: 8888
+
+munin:
+  install: false
+  admin:
+    user: admin
+    passwd: p4sswurd
+
+postfix:
+  enabled: true
+
+prometheus:
+  install: false
+  node_exporter: https://github.com/prometheus/node_exporter/releases/download/v1.0.1/node_exporter-1.0.1.linux-amd64.tar.gz
+  root: /usr/local/prometheus
+  url: https://github.com/prometheus/prometheus/releases/download/v2.19.1/prometheus-2.19.1.linux-amd64.tar.gz
+  user: prometheus
+
+rserve:
+  install: false
+  host: localhost
+  user: rserve
+  group: rserve
+  pass: rserve
+  port: 6311
+  workdir: /tmp/Rserv
+
+s3:
+  enabled: false
+  access_key: 4cc355_k3y
+  secret_access_key: s3cr3t_4cc355_k3y
+  bucket_name: s3-test
+  create_bucket: true
+  # for non-amazon services.
+  custom_endpoint_url: "http://localhost:4572"
+  download_redirect: true
+  files_type: s3
+  ingestsizelimit:
+  label: s3-test
+  # for localstack this must be true
+  path_style_access: true
+  region: us-east-1
+  storage_driver_id: s3
+  upload_redirect: true
+  url_expiration_minutes: 60
+
+schemaspy:
+  enabled: false
+  jarurl: https://github.com/schemaspy/schemaspy/releases/download/v6.1.0/schemaspy-6.1.0.jar
+
+shibboleth:
+  enabled: false
+  repo: "http://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/security:shibboleth.repo"
+  email: TODO
+  organizationName: TODO
+  organizationalUnitName: TODO
+  requestedAttributes:
+# the ones marked Required seem to be really required by dataverse
+   - '<md:RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" isRequired="true"/>'
+   - '<md:RequestedAttribute FriendlyName="email" Name="urn:oid:0.9.2342.19200300.100.1.3" isRequired="true"/>'
+   - '<md:RequestedAttribute FriendlyName="givenName" Name="urn:oid:2.5.4.42" isRequired="true"/>'
+   - '<md:RequestedAttribute FriendlyName="sn" Name="urn:oid:2.5.4.4" isRequired="true"/>'
+   - '<md:RequestedAttribute FriendlyName="eduPersonScopedAffiliation" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.9" />'
+#   - '<md:RequestedAttribute FriendlyName="affiliation" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.9" />'
+  organizationDisplayName: TODO
+  organizationURL: TODO
+  UIInfo: []
+## this is an example below
+#    - lang: en
+#      DisplayName: TODO
+#      Description: TODO
+#      InformationURL: TODO
+#      PrivacyStatementURL: TODO
+#      Logo:
+#        url: TODO
+#        height: TODO
+#        width: TODO
+  contactPerson: []
+## this is an example below
+#    - type: technical
+#      givenName: TODO
+#      surName: TODO
+#      emailAddress: TODO
+#    - type: support
+#      givenName: TODO
+#      surName: TODO
+#      emailAddress: TODO
+#    - type: administrative
+#      givenName: TODO
+#      surName: TODO
+#      emailAddress: TODO
+  SSO: "<SSO>SAML2 SAML1</SSO>"
+  MetadataProvider: '<MetadataProvider type="XML" file="dataverse-idp-metadata.xml" backingFilePath="local-idp-metadata.xml" legacyOrgNames="true" reloadInterval="7200"/>'
+
+sshkeys:
+  enabled: false
+  files:
+  urls:
+  user:
+


### PR DESCRIPTION
See also https://github.com/IQSS/dataverse/blob/v4.20/scripts/tests/ec2-memory-benchmark/README.md

This is based on dataverse/defaults/main.yml (still the first comment in the file because I wasn't sure if I should change it).

There are only two changes from main.yml:

- sample data is enabled
- rserve is disabled (just to speed up the time to spin up the instance)

Here's the diff

```
$ diff -u tests/group_vars/memorytests.yml defaults/main.yml 
--- tests/group_vars/memorytests.yml	2020-08-04 16:45:16.000000000 -0400
+++ defaults/main.yml	2020-08-04 16:43:26.000000000 -0400
@@ -130,7 +130,7 @@
   previewers:
     enabled: true
   sampledata:
-    enabled: true
+    enabled: false
     dir: /tmp/sampledata
     repo: https://github.com/IQSS/dataverse-sample-data.git
     branch: master
@@ -210,7 +210,7 @@
   user: prometheus
 
 rserve:
-  install: false
+  install: true
   host: localhost
   user: rserve
   group: rserve
```