### PR TITLE
Fix custom metadata block provisioning when controller machine != controlled machine

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -88,8 +88,9 @@ provisioner:
             user: counter
             year_month: "2018-05"
           custom_metadata_blocks:
-            enabled: false
-            urls: []
+            enabled: true
+            urls:
+              - https://github.com/IQSS/dataverse/files/3744336/codemeta.tsv.txt
           default:
             config:
           demo: false

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -53,7 +53,7 @@
     method: POST
     headers:
       Content-type: 'text/tab-separated-values'
-    src: '/tmp/dataverse/custom_metadata_blocks/{{ item }}'
+    src: '{{ item.path }}'
     remote_src: yes
   loop: '{{ custom_metadata_block_list.files }}'
   when: dataverse.custom_metadata_blocks.enabled == True

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -53,7 +53,8 @@
     method: POST
     headers:
       Content-type: 'text/tab-separated-values'
-    body: "{{ lookup('file', item.path) }}"
+    src: '/tmp/dataverse/custom_metadata_blocks/{{ item }}'
+    remote_src: yes
   loop: '{{ custom_metadata_block_list.files }}'
   when: dataverse.custom_metadata_blocks.enabled == True
 


### PR DESCRIPTION
Closes #25 

It seems the only part the really depends on the controller and controlled machine being the same is the tasks loading the custom metadata blocks. I have changed this so that the whole process is remote.