### PR TITLE
Don't fetch 'latest' resource when installing a specific release

### DIFF
--- a/tasks/dataverse-glassfish.yml
+++ b/tasks/dataverse-glassfish.yml
@@ -62,7 +62,7 @@
 
 - name: get patched grizzly jar for glassfish-4.1
   get_url:
-    url: http://guides.dataverse.org/en/latest/_static/installation/files/issues/2180/grizzly-patch/glassfish-grizzly-extra-all.jar
+    url: http://guides.dataverse.org/en/{{ dataverse.version if dataverse_branch == 'release' else 'latest' }}/_static/installation/files/issues/2180/grizzly-patch/glassfish-grizzly-extra-all.jar
     dest: '{{ glassfish_dir }}/glassfish/modules'
     owner: root
     group: root

--- a/tasks/dataverse-install.yml
+++ b/tasks/dataverse-install.yml
@@ -108,6 +108,7 @@
     path: /tmp/dvinstall/as-setup.sh
     regexp: '(.*)-Ddataverse.siteUrl(.*)'
     line: '  ./asadmin $ASADMIN_OPTS create-jvm-options "\-Ddataverse.siteUrl={{ siteUrl }}"'
+  when: dataverse.glassfish.zipurl is not match(".*glassfish-4.1.zip")
 
 - name: fire off installer
   shell: '/usr/bin/python /tmp/dvinstall/install.py -f --config_file=default.config --noninteractive > /tmp/dvinstall/install.out 2>&1'

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -73,7 +73,7 @@
 # integration tests require these
 - name: support sequential identifiers fetch current SQL script
   get_url:
-    url: http://guides.dataverse.org/en/latest/_downloads/createsequence.sql
+    url: http://guides.dataverse.org/en/{{ dataverse.version if dataverse_branch == 'release' else 'latest' }}/_downloads/createsequence.sql
     dest: /tmp/createsequence.sql
     mode: '0644'
 

--- a/tasks/dataverse-shibboleth.yml
+++ b/tasks/dataverse-shibboleth.yml
@@ -60,7 +60,7 @@
 
 - name: get shibAuthProvider.json to host
   get_url:
-    url: http://guides.dataverse.org/en/latest/_static/installation/files/etc/shibboleth/shibAuthProvider.json
+    url: http://guides.dataverse.org/en/{{ dataverse.version if dataverse_branch == 'release' else 'latest' }}/_static/installation/files/etc/shibboleth/shibAuthProvider.json
     dest: /tmp/shibAuthProvider.json
   register: shibAuthProvider_json_download
 


### PR DESCRIPTION
Fixes two bugs when installing Dataverse 4.20 (or any older release, presumably):

* Now that Dataverse 5.0 has been released, <http://guides.dataverse.org/en/latest/_static/installation/files/> points to <http://guides.dataverse.org/en/5.0/_static/installation/files/>, which doesn't include some files required by the 4.20 installation.
* The "patch as-setup.sh" step cannot be executed, because the target file does not exist in the 4.20 installation.

Fixed this by replacing `latest` with a JinJa2 expression that fills in `dataverse.version` if `dataverse_branch` was set to `release` and by guarding the "patch as-setup.sh" step with the check if glassfish 4.1 is used.

Admittedly, the default `latest` will never work in the Glassfish-only steps, but I don't know what other default I could fill in here.