### PR TITLE
Fix Shibboleth support in RedHat with SELinux

### DIFF
--- a/files/00-shib.conf
+++ b/files/00-shib.conf
@@ -1,0 +1,1 @@
+LoadModule mod_shib /usr/lib64/shibboleth/mod_shib_24.so

--- a/files/install-mod_shib-to-shibd.sh
+++ b/files/install-mod_shib-to-shibd.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+checkmodule -m -M -o mod_shib-to-shibd.mod mod_shib-to-shibd.te
+semodule_package -o mod_shib-to-shibd.pp -m mod_shib-to-shibd.mod
+semodule -i mod_shib-to-shibd.pp

--- a/files/mod_shib-to-shibd.te
+++ b/files/mod_shib-to-shibd.te
@@ -1,0 +1,12 @@
+module mod_shib-to-shibd 1.0;
+require {
+       type var_run_t;
+       type httpd_t;
+       type initrc_t;
+       class sock_file write;
+       class unix_stream_socket connectto;
+}
+
+#============= httpd_t ==============
+allow httpd_t initrc_t:unix_stream_socket connectto;
+allow httpd_t var_run_t:sock_file write;

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,14 +14,14 @@ platforms:
       - network_name: forwarded_port
         guest: 80
         host: 8080
-#  - name: centos7
-#    box: "bento/centos-7.8"
-#    memory: 3072
-#    cpus: 2
-#    interfaces:
-#      - network_name: forwarded_port
-#        guest: 80
-#        host: 8081
+  - name: centos7
+    box: "bento/centos-7.8"
+    memory: 3072
+    cpus: 2
+    interfaces:
+      - network_name: forwarded_port
+        guest: 80
+        host: 8081
 # TODO: Fix error during installation on Ubuntu
 #  - name: unbuntu-16.04
 #    box: "bento/ubuntu-16.04"
@@ -43,6 +43,10 @@ provisioner:
       pipelining: True
       control_path: '/tmp/ansible-ssh-%%h-%%p-%%r'
   inventory:
+    host_vars:
+      centos8:
+        shibboleth:
+          repo: 'http://download.opensuse.org/repositories/security:/shibboleth/CentOS_8/security:shibboleth.repo'
     group_vars:
       all:
         rserve:
@@ -173,5 +177,26 @@ provisioner:
             argument: '-DcompilerArgument=-Xlint:unchecked test -P all-unit-tests'
           usermgmtkey: burrito
           version: '4.20'
+        shibboleth:
+          enabled: true
+          repo: "http://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/security:shibboleth.repo"
+          email: TODO
+          organizationName: TODO
+          organizationalUnitName: TODO
+          requestedAttributes:
+            # the ones marked Required seem to be really required by dataverse
+            - '<md:RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" isRequired="true"/>'
+            - '<md:RequestedAttribute FriendlyName="email" Name="urn:oid:0.9.2342.19200300.100.1.3" isRequired="true"/>'
+            - '<md:RequestedAttribute FriendlyName="givenName" Name="urn:oid:2.5.4.42" isRequired="true"/>'
+            - '<md:RequestedAttribute FriendlyName="sn" Name="urn:oid:2.5.4.4" isRequired="true"/>'
+            - '<md:RequestedAttribute FriendlyName="eduPersonScopedAffiliation" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.9" />'
+          #   - '<md:RequestedAttribute FriendlyName="affiliation" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.9" />'
+          organizationDisplayName: TODO
+          organizationURL: TODO
+          UIInfo: []
+          contactPerson: []
+          SSO: "<SSO>SAML2 SAML1</SSO>"
+          MetadataProvider: '<MetadataProvider type="XML" file="dataverse-idp-metadata.xml" backingFilePath="local-idp-metadata.xml" legacyOrgNames="true" reloadInterval="7200"/>'
+
 verifier:
   name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -11,3 +11,13 @@
   - name: 'dataverse is up'
     assert:
       that: '{{ get_dataverse_homepage_result.status == 200  }}'
+
+  - name: try to access the Shibboleth metadata
+    uri:
+      url: 'http://localhost/Shibboleth.sso/Metadata'
+    register: get_shib_metadata_result
+    ignore_errors: yes
+
+  - name: 'shib is running'
+    assert:
+      that: '{{ get_shib_metadata_result.status == 200  }}'

--- a/tasks/dataverse-glassfish.yml
+++ b/tasks/dataverse-glassfish.yml
@@ -62,7 +62,7 @@
 
 - name: get patched grizzly jar for glassfish-4.1
   get_url:
-    url: http://guides.dataverse.org/en/latest/_static/installation/files/issues/2180/grizzly-patch/glassfish-grizzly-extra-all.jar
+    url: http://guides.dataverse.org/en/{{ dataverse.version if dataverse_branch == 'release' else 'latest' }}/_static/installation/files/issues/2180/grizzly-patch/glassfish-grizzly-extra-all.jar
     dest: '{{ glassfish_dir }}/glassfish/modules'
     owner: root
     group: root

--- a/tasks/dataverse-install.yml
+++ b/tasks/dataverse-install.yml
@@ -108,6 +108,7 @@
     path: /tmp/dvinstall/as-setup.sh
     regexp: '(.*)-Ddataverse.siteUrl(.*)'
     line: '  ./asadmin $ASADMIN_OPTS create-jvm-options "\-Ddataverse.siteUrl={{ siteUrl }}"'
+  when: dataverse.glassfish.zipurl is not match(".*glassfish-4.1.zip")
 
 - name: fire off installer
   shell: '/usr/bin/python /tmp/dvinstall/install.py -f --config_file=default.config --noninteractive > /tmp/dvinstall/install.out 2>&1'

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -73,7 +73,7 @@
 # integration tests require these
 - name: support sequential identifiers fetch current SQL script
   get_url:
-    url: http://guides.dataverse.org/en/latest/_downloads/createsequence.sql
+    url: http://guides.dataverse.org/en/{{ dataverse.version if dataverse_branch == 'release' else 'latest' }}/_downloads/createsequence.sql
     dest: /tmp/createsequence.sql
     mode: '0644'
 

--- a/tasks/dataverse-shibboleth.yml
+++ b/tasks/dataverse-shibboleth.yml
@@ -60,7 +60,7 @@
 
 - name: get shibAuthProvider.json to host
   get_url:
-    url: http://guides.dataverse.org/en/latest/_static/installation/files/etc/shibboleth/shibAuthProvider.json
+    url: http://guides.dataverse.org/en/{{ dataverse.version if dataverse_branch == 'release' else 'latest' }}/_static/installation/files/etc/shibboleth/shibAuthProvider.json
     dest: /tmp/shibAuthProvider.json
   register: shibAuthProvider_json_download
 

--- a/tasks/dataverse-shibboleth.yml
+++ b/tasks/dataverse-shibboleth.yml
@@ -82,3 +82,41 @@
     - shib2
   when: ansible_os_family == "Debian"    ## CHECKME -- does this need to be Debian-specific?
   notify: enable and restart apache
+
+# /etc/httpd/conf.d/shib.conf also loads the module, but is not guaranteed to do so before http.proxy.conf checks the mod_shib variable
+- name: load shib module on RedHat
+  copy:
+    src: "00-shib.conf"
+    dest: "/etc/httpd/conf.modules.d/"
+  when: ansible_os_family == "RedHat"
+  notify: enable and restart apache
+
+- set_fact:
+    selinux_enabled: "{{ ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled' }}"
+
+- name: upload mod_shib-to-shibd.te and installer
+  copy:
+    src: '{{ item.file }}'
+    dest: '/tmp'
+    mode: '{{ item.mode }}'
+  with_items:
+    - { file: mod_shib-to-shibd.te, mode: '0400' }
+    - { file: install-mod_shib-to-shibd.sh, mode: '0700' }
+  when: selinux_enabled
+
+- name: install the policy to allow mod_shib to talk to shibd
+  command:
+    cmd: '/tmp/install-mod_shib-to-shibd.sh'
+    chdir: '/tmp'
+  when: selinux_enabled
+
+- name: remove policy files after install
+  file:
+    path: '/tmp/{{ item }}'
+    state: absent
+  with_items:
+    - install-mod_shib-to-shibd.sh
+    - mod_shib-to-shibd.te
+    - mod_shib-to-shibd.pp
+    - mod_shib-to-shibd.mod
+  when: selinux_enabled


### PR DESCRIPTION
Currently, the SELinux installation has two problems on CentOS/Redhat: 

* The mod_shib module is loaded after the http.proxy.conf file was read, so that the conditional statements about Shibboleth paths were not executed. Fixed this by loading the mod_shib module in `/etc/httpd/conf.modules.d`, which seems to be more the standard way, anyway.
* If SELinux is enabled (as it should be) mod_shib will be blocked from talking to shibd. Fixed this by installing the policy as described in <http://guides.dataverse.org/en/5.0/installation/shibboleth.html#reconfigure-selinux-to-accommodate-shibboleth>.

Note: this pr includes #33