### PR TITLE
Option to host dataverse previewers locally

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -131,6 +131,9 @@ dataverse:
   memheap: 4096
   previewers:
     enabled: true
+    on_same_server: true
+    zip_url: https://github.com/GlobalDataverseCommunityConsortium/dataverse-previewers/archive/1.1.zip
+    dir: /var/www/html
   sampledata:
     enabled: false
     dir: /tmp/sampledata

--- a/tasks/dataverse-previewers.yml
+++ b/tasks/dataverse-previewers.yml
@@ -4,11 +4,32 @@
   debug:
     msg: '##### DATAVERSE PREVIEWERS #####'
 
+- name: download and unzip dataverse previewers to apache server
+  unarchive:
+    src: '{{ dataverse.previewers.zip_url }}'
+    dest: '{{ dataverse.previewers.dir }}'
+    remote_src: yes
+    owner: root
+    group: root
+    mode: "u+x,g+x,o+x"
+  when: dataverse.previewers.on_same_server == true
+
+- name: rename dataverse previewers folder
+  shell: 'mv {{ dataverse.previewers.dir }}/dataverse-previewers-?.? {{ dataverse.previewers.dir }}/dataverse-previewers'
+  when: dataverse.previewers.on_same_server == true
+
 - name: upload dataverse-previewers.sh script
   copy:
     src: dataverse-previewers.sh
     dest: '{{ ansible_user_dir }}'
     mode: 0700
+
+- name: modify dataverse-previewers.sh script for local hosting previewers
+  replace:
+    path: '{{ ansible_user_dir }}/dataverse-previewers.sh'
+    regexp: 'https://globaldataversecommunityconsortium.github.io'
+    replace: '{{ dataverse.payara.siteurl }}'
+  when: dataverse.previewers.on_same_server == true
 
 - name: enable dataverse-previewers
   shell: '{{ ansible_user_dir }}/dataverse-previewers.sh'

--- a/templates/http.proxy.conf.j2
+++ b/templates/http.proxy.conf.j2
@@ -93,6 +93,11 @@ Listen 443 https
   ProxyPassMatch ^/schemaspy !
 {% endif %}
 
+{% if dataverse.previewers.on_same_server %}
+  # allow previewers
+  ProxyPassMatch ^/dataverse-previewers !
+{% endif %}
+
 {% if shibboleth.enabled %}
 
   <IfModule mod_shib>

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -127,6 +127,9 @@ dataverse:
   memheap: 4096
   previewers:
     enabled: true
+    on_same_server: true
+    zip_url: https://github.com/GlobalDataverseCommunityConsortium/dataverse-previewers/archive/1.1.zip
+    dir: /var/www/html
   sampledata:
     enabled: false
     dir: /tmp/sampledata

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -129,6 +129,9 @@ dataverse:
   memheap: 2048
   previewers:
     enabled: true
+    on_same_server: true
+    zip_url: https://github.com/GlobalDataverseCommunityConsortium/dataverse-previewers/archive/1.1.zip
+    dir: /var/www/html
   sampledata:
     enabled: true
     dir: /tmp/sampledata

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -36,7 +36,7 @@ dataverse:
     blocked_endpoints: "admin,test"
     blocked_policy: "localhost-only"
     location: "http://localhost:8080/api"
-    test_suite: false
+    test_suite: true
     # possible test values from https://github.com/IQSS/dataverse/blob/develop/conf/docker-aio/run-test-suite.sh#L11
     # beware DataversesIT and DatasetsIT at minimum must be run for any other tests to succeed. have fun.
     #tests: "DataversesIT,DatasetsIT,AdminIT"
@@ -78,7 +78,7 @@ dataverse:
       - https://github.com/IQSS/dataverse/files/3744336/codemeta.tsv.txt
   default:
     config:
-    storage_id: file
+    storage_id: s3
   demo: false
   doi:
     authority: "10.5072"
@@ -92,10 +92,10 @@ dataverse:
     shoulder: "FK2/"
   externaltools:
     datacurationtool:
-      enabled: false
+      enabled: true
       method: demo
     dataexplorer:
-      enabled: false
+      enabled: true
     wholetale:
       enabled: false
   ## The first item of 'filesdirs' is the default filestore
@@ -203,7 +203,7 @@ prometheus:
   user: prometheus
 
 rserve:
-  install: false
+  install: true
   host: localhost
   user: rserve
   group: rserve

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -97,7 +97,7 @@ dataverse:
     dataexplorer:
       enabled: true
     wholetale:
-      enabled: false
+      enabled: true
   ## The first item of 'filesdirs' is the default filestore
   ## If you change the label, be prepared to change the SQL database if there are already files here
   ## It is better practice to add a new data store and then migrate to it later

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -36,7 +36,7 @@ dataverse:
     blocked_endpoints: "admin,test"
     blocked_policy: "localhost-only"
     location: "http://localhost:8080/api"
-    test_suite: true
+    test_suite: false
     # possible test values from https://github.com/IQSS/dataverse/blob/develop/conf/docker-aio/run-test-suite.sh#L11
     # beware DataversesIT and DatasetsIT at minimum must be run for any other tests to succeed. have fun.
     #tests: "DataversesIT,DatasetsIT,AdminIT"
@@ -78,7 +78,7 @@ dataverse:
       - https://github.com/IQSS/dataverse/files/3744336/codemeta.tsv.txt
   default:
     config:
-    storage_id: s3
+    storage_id: file
   demo: false
   doi:
     authority: "10.5072"
@@ -92,12 +92,12 @@ dataverse:
     shoulder: "FK2/"
   externaltools:
     datacurationtool:
-      enabled: true
+      enabled: false
       method: demo
     dataexplorer:
-      enabled: true
+      enabled: false
     wholetale:
-      enabled: true
+      enabled: false
   ## The first item of 'filesdirs' is the default filestore
   ## If you change the label, be prepared to change the SQL database if there are already files here
   ## It is better practice to add a new data store and then migrate to it later
@@ -117,7 +117,7 @@ dataverse:
     adminpass: notPr0d
     launch_timeout: 180
     request_timeout: 1800
-    siteurl: 
+    siteurl: http://0.0.0.0
     root: /usr/local
     dir: payara5
     zipurl: https://github.com/payara/Payara/releases/download/payara-server-5.2020.2/payara-5.2020.2.zip
@@ -131,6 +131,9 @@ dataverse:
   memheap: 1024
   previewers:
     enabled: true
+    on_same_server: true
+    zip_url: https://github.com/GlobalDataverseCommunityConsortium/dataverse-previewers/archive/1.1.zip
+    dir: /var/www/html
   sampledata:
     enabled: false
     dir: /tmp/sampledata
@@ -200,7 +203,7 @@ prometheus:
   user: prometheus
 
 rserve:
-  install: true
+  install: false
   host: localhost
   user: rserve
   group: rserve


### PR DESCRIPTION
There are several reasons why you might want to create a copy of the previewer resources and host them on your own server:

- Reduce the risk o cross site scripting problems. (You don't have to allow CORS.)
- Keep control over when the previewers are updated in your instance of Dataverse. 

(If you want to test the previewers locally via localhost the siteUrl value `http://0.0.0.0` is required, i'm not sure why `http://localhost` does not work...)