### PR TITLE
bump to Dataverse 5.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -164,7 +164,7 @@ dataverse:
     enabled: false
     argument: '-DcompilerArgument=-Xlint:unchecked test -P all-unit-tests'
   usermgmtkey: burrito
-  version: '5.0'
+  version: '5.1'
 
 build_guides: false
 

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -160,7 +160,7 @@ dataverse:
     enabled: true
     argument: '-DcompilerArgument=-Xlint:unchecked test -P all-unit-tests'
   usermgmtkey: burrito
-  version: '5.0'
+  version: '5.1'
 
 build_guides: false
 

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -162,7 +162,7 @@ dataverse:
     enabled: false
     argument: '-DcompilerArgument=-Xlint:unchecked test -P all-unit-tests'
   usermgmtkey: burrito
-  version: '4.20'
+  version: '5.1'
 
 build_guides: false
 

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -78,7 +78,7 @@ dataverse:
       - https://github.com/IQSS/dataverse/files/3744336/codemeta.tsv.txt
   default:
     config:
-    storage_id: s3
+    storage_id: file
   demo: false
   doi:
     authority: "10.5072"
@@ -164,7 +164,7 @@ dataverse:
     enabled: false
     argument: '-DcompilerArgument=-Xlint:unchecked test -P all-unit-tests'
   usermgmtkey: burrito
-  version: '5.0'
+  version: '5.1'
 
 build_guides: false
 


### PR DESCRIPTION
bump to dataverse.version to 5.1

vagrant.yml should be using file storage by default, not s3.