### PR TITLE
Add setting for file fixity algorithm

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -128,6 +128,7 @@ dataverse:
     home: /tmp/jacoco
     version: 0.8.1
   maxfileuploadsizeinbytes:
+  file_fixity_checksum_algorithm: "MD5"
   memheap: 4096
   options:
     tabularingestsizelimit: 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -145,6 +145,7 @@ provisioner:
             home: /tmp/jacoco
             version: 0.8.1
           maxfileuploadsizeinbytes:
+          file_fixity_checksum_algorithm: "MD5"
           memheap: 2048
           previewers:
             enabled: true

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -111,7 +111,7 @@
     - { prop: ":AllowSignUp", val: "{{ dataverse.allow_signups }}", desc: "don't allow self-signup"}
     - { prop: ":BlockedApiEndpoints", val: "admin,test", desc: "APIs that are controlled"}
     - { prop: ":BlockedApiPolicy", val: "localhost-only", desc: "control API access"}
-    - { prop: ":FileFixityChecksumAlgorithm", val: "{{ dataverse.file_fixity_checksum_algorithm }}", desc: "checksum algorithm used file fixity" }
+    - { prop: ":FileFixityChecksumAlgorithm", val: "{{ dataverse.file_fixity_checksum_algorithm }}", desc: "checksum algorithm used for file fixity" }
 
 - name: enable AllowApiTokenLookupViaApi for those so inclined
   shell: 'curl -X PUT -d true http://localhost:8080/api/admin/settings/:AllowApiTokenLookupViaApi'

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -111,6 +111,7 @@
     - { prop: ":AllowSignUp", val: "{{ dataverse.allow_signups }}", desc: "don't allow self-signup"}
     - { prop: ":BlockedApiEndpoints", val: "admin,test", desc: "APIs that are controlled"}
     - { prop: ":BlockedApiPolicy", val: "localhost-only", desc: "control API access"}
+    - { prop: ":FileFixityChecksumAlgorithm", "{{ dataverse.file_fixity_checksum_algorithm }}", desc: "checksum algorithm used file fixity" }
 
 - name: enable AllowApiTokenLookupViaApi for those so inclined
   shell: 'curl -X PUT -d true http://localhost:8080/api/admin/settings/:AllowApiTokenLookupViaApi'

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -111,7 +111,7 @@
     - { prop: ":AllowSignUp", val: "{{ dataverse.allow_signups }}", desc: "don't allow self-signup"}
     - { prop: ":BlockedApiEndpoints", val: "admin,test", desc: "APIs that are controlled"}
     - { prop: ":BlockedApiPolicy", val: "localhost-only", desc: "control API access"}
-    - { prop: ":FileFixityChecksumAlgorithm", "{{ dataverse.file_fixity_checksum_algorithm }}", desc: "checksum algorithm used file fixity" }
+    - { prop: ":FileFixityChecksumAlgorithm", val: "{{ dataverse.file_fixity_checksum_algorithm }}", desc: "checksum algorithm used file fixity" }
 
 - name: enable AllowApiTokenLookupViaApi for those so inclined
   shell: 'curl -X PUT -d true http://localhost:8080/api/admin/settings/:AllowApiTokenLookupViaApi'

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -124,6 +124,7 @@ dataverse:
     home: /tmp/jacoco
     version: 0.8.1
   maxfileuploadsizeinbytes:
+  file_fixity_checksum_algorithm: "MD5"
   memheap: 4096
   options:
     tabularingestsizelimit: 

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -126,6 +126,7 @@ dataverse:
     home: /tmp/jacoco
     version: 0.8.1
   maxfileuploadsizeinbytes:
+  file_fixity_checksum_algorithm: "MD5"
   memheap: 2048
   options:
     tabularingestsizelimit: 

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -128,6 +128,7 @@ dataverse:
     home: /tmp/jacoco
     version: 0.8.1
   maxfileuploadsizeinbytes:
+  file_fixity_checksum_algorithm: "MD5"
   memheap: 1024
   options:
     tabularingestsizelimit: 


### PR DESCRIPTION
Makes file fixity algorithm configurable but keeps MD5 as the default.