### PR TITLE
update s3_cors.json template for 5.1.1

### DIFF
--- a/templates/s3_cors.json.j2
+++ b/templates/s3_cors.json.j2
@@ -2,7 +2,7 @@
   "CORSRules": [
      {
         "AllowedHeaders": ["*"],
-        "ExposedHeaders": ["ETag"],
+        "ExposeHeader": ["ETag"],
         "AllowedMethods": ["PUT", "GET"],
         "AllowedOrigins": ["*"]
      }

--- a/templates/s3_cors.json.j2
+++ b/templates/s3_cors.json.j2
@@ -1,9 +1,10 @@
 {
   "CORSRules": [
      {
-        "AllowedOrigins": ["{{ siteUrl }}"],
         "AllowedHeaders": ["*"],
-        "AllowedMethods": ["PUT", "GET"]
+        "ExposedHeaders": ["ETag"],
+        "AllowedMethods": ["PUT", "GET"],
+        "AllowedOrigins": ["*"]
      }
   ]
 }


### PR DESCRIPTION
per today's Slack msgs in dv-prod-ops.

as-is, s3_cors.json no longer need be a template, but i'll leave it as such in case we revert to any configurable settings (such as siteUrl)