### PR TITLE
disable filepids when set to false

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -130,6 +130,7 @@ dataverse:
   file_fixity_checksum_algorithm: "MD5"
   memheap: 4096
   options:
+    filepids: 
     maxfileuploadsizeinbytes:
     tabularingestsizelimit: 
   previewers:

--- a/tasks/dataverse-optional-settings.yml
+++ b/tasks/dataverse-optional-settings.yml
@@ -4,6 +4,10 @@
   shell: 'curl -X PUT -d true http://localhost:8080/api/admin/settings/:AllowApiTokenLookupViaApi'
   when: dataverse.api.allow_lookup == true
 
+- name: disable FilePIDs when set to false
+  shell: 'curl -X PUT -d {{ dataverse.options.filepids }} {{ dataverse.api.location }}/admin/settings/:FilePIDsEnabled'
+  when: dataverse.options.filepids == false
+
 - name: set MaxFileUploadSizeInBytes when provided
   shell: 'curl -X PUT -d {{ dataverse.options.maxfileuploadsizeinbytes }} {{ dataverse.api.location }}/admin/settings/:MaxFileUploadSizeInBytes'
   when: dataverse.options.maxfileuploadsizeinbytes

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -126,6 +126,7 @@ dataverse:
   file_fixity_checksum_algorithm: "MD5"
   memheap: 4096
   options:
+    filepids: 
     maxfileuploadsizeinbytes:
     tabularingestsizelimit: 
   previewers:

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -128,6 +128,7 @@ dataverse:
   file_fixity_checksum_algorithm: "MD5"
   memheap: 2048
   options:
+    filepids: 
     maxfileuploadsizeinbytes:
     tabularingestsizelimit: 
   previewers:

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -130,6 +130,7 @@ dataverse:
   file_fixity_checksum_algorithm: "MD5"
   memheap: 1024
   options:
+    filepids: 
     maxfileuploadsizeinbytes:
     tabularingestsizelimit: 
   previewers:


### PR DESCRIPTION
changed my mind; Dataverse's default is dataverse-ansible's default.