### PR TITLE
WIP Added apache plugin to certbot

### DIFF
--- a/tasks/certbot.yml
+++ b/tasks/certbot.yml
@@ -10,7 +10,9 @@
 
 - name: install certbot package
   yum:
-    name: certbot
+    name:
+      - certbot
+      - python3-certbot-apache
     state: latest
 
 - name: check if certificate already exists
@@ -25,7 +27,7 @@
   when: not letsencrypt_cert.stat.exists
 
 - name: Generate new certificate if one doesn't exist.
-  command: 'certbot certonly --standalone --noninteractive --agree-tos --email {{ letsencrypt.certbot.email }} -d {{ servername }}'
+  command: 'certbot --apache --noninteractive --agree-tos --email {{ letsencrypt.certbot.email }} -d {{ servername }}'
   when: not letsencrypt_cert.stat.exists
 
 - name: start services after cert has been generated


### PR DESCRIPTION
In the original code if certbot was used, the apache config files was not updated. We here switch to using the apache certbot plugin and running certbot with the `--apache` flag.