### PR TITLE
don't duplicate Listen 443 statement

### DIFF
--- a/tasks/dataverse-apache.yml
+++ b/tasks/dataverse-apache.yml
@@ -12,7 +12,7 @@
   - ansible_distribution_major_version == "8"
 
 - name: allow apache to read user content by default
-  shell: 'setsebool -P httpd_read_user_content 1'
+  shell: '/usr/sbin/setsebool -P httpd_read_user_content 1'
   when:
   - ansible_os_family == "RedHat"
   - ansible_distribution_major_version == "8"

--- a/templates/http.proxy.conf.j2
+++ b/templates/http.proxy.conf.j2
@@ -1,8 +1,5 @@
 {% if apache.ssl.enabled %}
 <IfModule ssl_module>
-  {% if ansible_os_family == "RedHat" %}
-Listen 443 https
-  {% endif %}
 
   {% if ansible_os_family == "RedHat" %}
   SSLPassPhraseDialog exec:/usr/libexec/httpd-ssl-pass-dialog
@@ -37,8 +34,9 @@ Listen 443 https
     LogLevel warn
 
     SSLEngine on
-    SSLProtocol all -SSLv2
-    SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
+    SSLProtocol -all +TLSv1.3
+    SSLHonorCipherOrder on
+    SSLCipherSuite kEECDH:+kEECDH+SHA:kEDH:+kEDH+SHA:+kEDH+CAMELLIA:kECDH:+kECDH+SHA:kRSA:+kRSA+SHA:+kRSA+CAMELLIA:!aNULL:!eNULL:!SSLv2:!RC4:!DES:!EXP:!SEED:!IDEA:!3DES
   {% if apache.ssl.remote_cert %}
     SSLCertificateFile {{ apache.ssl.cert }}
     SSLCertificateKeyFile {{ apache.ssl.key }}


### PR DESCRIPTION
closes #105 

centos 8.3 httpd fails as `Listen 443` directive is now explicitly provided in `/etc/httpd/conf/httpd.conf`