### PR TITLE
Restore dataverse-apache.yml idempotence (new attempt) 

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,14 +6,14 @@ driver:
   provider:
     name: virtualbox
 platforms:
-  - name: centos8
-    box: "bento/centos-8.2"
-    memory: 3072
-    cpus: 2
-    interfaces:
-      - network_name: forwarded_port
-        guest: 80
-        host: 8080
+#  - name: centos8
+#    box: "bento/centos-8.2"
+#    memory: 3072
+#    cpus: 2
+#    interfaces:
+#      - network_name: forwarded_port
+#        guest: 80
+#        host: 8080
   - name: centos7
     box: "bento/centos-7.8"
     memory: 3072
@@ -43,161 +43,19 @@ provisioner:
       pipelining: True
       control_path: '/tmp/ansible-ssh-%%h-%%p-%%r'
   inventory:
-    host_vars:
-      centos8:
-        shibboleth:
-          repo: 'http://download.opensuse.org/repositories/security:/shibboleth/CentOS_8/security:shibboleth.repo'
     group_vars:
       all:
         rserve:
           install: false
-        dataverse_branch: release
-        dataverse_repo: https://github.com/IQSS/dataverse.git
-        dataverse:
-          adminpass: admin1
-          allow_signups: true
-          api:
-            allow_lookup: false
-            blocked_endpoints: "admin,test"
-            blocked_policy: "localhost-only"
-            location: "http://localhost:8080/api"
-            test_suite: false
-          branding:
-            enabled: false
-            directory: "{{ playbook_dir }}/files/branding"
-            favicons_directory: "{{ playbook_dir }}/files/favicons"
-            fileSettings:
-              - setting: FooterCustomizationFile
-                file: custom-footer.html
-              - setting: ApplicationTermsOfUse
-                file: apptou.html
-            otherSettings:
-              - setting: ExcludeEmailFromExport
-                value: "true"
-          copyright: "&nbsp;TEST"
-          counter:
-            enabled: false
-            geoipdir: maxmind_geoip
-            geoipfile: GeoLite2-Country.mmdb
-            hub_api_token: set_me_in_secrets
-            hub_base_url: "https://api.datacite.org"
-            machines_url: "https://raw.githubusercontent.com/CDLUC3/Make-Data-Count/master/user-agents/lists/machine.txt"
-            maxmind_geoip_country_path: "maxmind_geoip/GeoLite2-Country.mmdb"
-            output_file: "/dataverse/sushi_sample_logs"
-            output_format: json
-            platform: dash
-            robots_url: "https://raw.githubusercontent.com/CDLUC3/Make-Data-Count/master/user-agents/lists/robot.txt"
-            version: "0.1"
-            upload_to_hub: False
-            user: counter
-            year_month: "2018-05"
-          custom_metadata_blocks:
-            enabled: true
-            urls:
-              - https://github.com/IQSS/dataverse/files/3744336/codemeta.tsv.txt
-          default:
-            config:
-          demo: false
-          doi:
-            authority: "10.5072"
-            baseurl: "https://mds.test.datacite.org/"
-            mdcbaseurl: "https://api.test.datacite.org/"
-            username: "testaccount"
-            password: "notmypassword"
-            protocol: doi
-            provider: FAKE
-            shoulder: "FK2/"
-          externaltools:
-            datacurationtool:
-              enabled: false
-              method: demo
-            dataexplorer:
-              enabled: false
-            wholetale:
-              enabled: false
-          ## The first item of 'filesdirs' is the default filestore
-          ## If you change the label, be prepared to change the SQL database if there are already files here
-          ## It is better practice to add a new data store and then migrate to it later
-          ## Also, changing the default storage takes effect immediately for temp files, but
-          ## only after restart for publishing (i.e. without restart the temp files will be moved to the old default data store at publish time).
-          filesdirs:
-            - label: file
-              path: /usr/local/dvn/data
-          #   - label: label
-          #     path: /path/to/filestore   ## this is a sample entry for further file stores
-          glassfish:
-            user: glassfish
-            group: glassfish
-            domain: domain1
-            logformat: ulf
-            adminuser: admin
-            adminpass: notPr0d
-            siteurl:
-            timeout: 180
-            request_timeout: 1800
-            root: /usr/local
-            dir: glassfish4
-            zipurl: http://download.oracle.com/glassfish/4.1/release/glassfish-4.1.zip
-            zipchecksum: sha256:3edc5fc72b8be241a53eae83c22f274479d70e15bdfba7ba2302da5260f23e9d
-          google_analytics_key:
-          jacoco:
-            enabled: false
-            home: /tmp/jacoco
-            version: 0.8.1
-          maxfileuploadsizeinbytes:
-          file_fixity_checksum_algorithm: "MD5"
-          memheap: 2048
-          previewers:
-            enabled: true
-          sampledata:
-            enabled: false
-            dir: /tmp/sampledata
-            repo: https://github.com/IQSS/dataverse-sample-data.git
-            branch: master
-            venv: /tmp/sampledata/venv
-          custom_sampledata:
-            enabled: false
-            custom_sampledir: "{{ playbook_dir }}/custom_sampledata"
-            custom_sampledatasets: "{{ playbook_dir }}/custom_sampledata/datasets"
-            custom_sampledataverses: "{{ playbook_dir }}/custom_sampledata/dataverses"
-            custom_sampleusers: "{{ playbook_dir }}/custom_sampledata/users"
-            custom_samplefiles: "{{ playbook_dir }}/custom_sampledata/files"
-          service_email: noreply@dataverse.yourinstitution.edu
-          smtp: localhost # or the FQDN of your organization's SMTP relay
-          solr:
-            group: solr
-            root: /usr/local/solr
-            user: solr
-            version: 7.7.2
-            checksum: sha256:eb8ee4038f25364328355de3338e46961093e39166c9bcc28b5915ae491320df
-            listen: 127.0.0.1
-          srcdir: /tmp/dataverse
-          thumbnails: true
-          unittests:
-            enabled: false
-            argument: '-DcompilerArgument=-Xlint:unchecked test -P all-unit-tests'
-          usermgmtkey: burrito
-          version: '4.20'
+          host: localhost
+          user: rserve
+          group: rserve
+          pass: rserve
+          port: 6311
+          workdir: /tmp/Rserv
+    host_vars:
+      centos8:
         shibboleth:
-          enabled: true
-          repo: "http://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/security:shibboleth.repo"
-          email: TODO
-          organizationName: TODO
-          organizationalUnitName: TODO
-          requestedAttributes:
-            # the ones marked Required seem to be really required by dataverse
-            - '<md:RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" isRequired="true"/>'
-            - '<md:RequestedAttribute FriendlyName="email" Name="urn:oid:0.9.2342.19200300.100.1.3" isRequired="true"/>'
-            - '<md:RequestedAttribute FriendlyName="givenName" Name="urn:oid:2.5.4.42" isRequired="true"/>'
-            - '<md:RequestedAttribute FriendlyName="sn" Name="urn:oid:2.5.4.4" isRequired="true"/>'
-            - '<md:RequestedAttribute FriendlyName="eduPersonScopedAffiliation" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.9" />'
-          #   - '<md:RequestedAttribute FriendlyName="affiliation" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.9" />'
-          organizationDisplayName: TODO
-          organizationURL: TODO
-          UIInfo: []
-          contactPerson: []
-          SSO: "<SSO>SAML2 SAML1</SSO>"
-          MetadataProvider: '<MetadataProvider type="XML" file="dataverse-idp-metadata.xml" backingFilePath="local-idp-metadata.xml" legacyOrgNames="true" reloadInterval="7200"/>'
-
+          repo: 'http://download.opensuse.org/repositories/security:/shibboleth/CentOS_8/security:shibboleth.repo'
 verifier:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,14 +6,14 @@ driver:
   provider:
     name: virtualbox
 platforms:
-#  - name: centos8
-#    box: "bento/centos-8.2"
-#    memory: 3072
-#    cpus: 2
-#    interfaces:
-#      - network_name: forwarded_port
-#        guest: 80
-#        host: 8080
+  - name: centos8
+    box: "bento/centos-8.2"
+    memory: 3072
+    cpus: 2
+    interfaces:
+      - network_name: forwarded_port
+        guest: 80
+        host: 8080
   - name: centos7
     box: "bento/centos-7.8"
     memory: 3072
@@ -38,6 +38,7 @@ provisioner:
   config_options:
     defaults:
       remote_tmp: '/tmp'
+      # TODO: find alternative approach to 'merge', which is now deprecated
       hash_behaviour: 'merge'
     ssh_connection:
       pipelining: True

--- a/tasks/dataverse-apache.yml
+++ b/tasks/dataverse-apache.yml
@@ -5,24 +5,35 @@
   debug:
     msg: '##### APACHE/HTTPD #####'
 
-- name: Install dependencies for SELinux modules
-  pip:
+- name: install dependencies for SELinux modules on RedHat 8
+  yum:
     name:
-    - libselinux-python
-    - policycoreutils-python
-
-# TODO: replace with ansible.posix.seboolean call
-- name: allow apache to make outbound connections
-  shell: '/usr/sbin/setsebool -P httpd_can_network_connect 1'
+      - python3-libselinux
+      - python3-libsemanage
   when:
-  - ansible_os_family == "RedHat"
-  - ansible_distribution_major_version == "8"
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == "8"
 
-- name: allow apache to read user content by default
-  shell: 'setsebool -P httpd_read_user_content 1'
+- name: install dependencies for SELinux modules on RedHat 7
+  yum:
+    name:
+      - libselinux-python
+      - libsemanage-python
   when:
-  - ansible_os_family == "RedHat"
-  - ansible_distribution_major_version == "8"
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == "7"
+
+- name: set SELinux boolean
+  ansible.posix.seboolean:
+    name: "{{ item }}"
+    state: yes
+    persistent: yes
+  with_items:
+    - httpd_can_network_connect
+    - httpd_read_user_content
+  when:
+    - ansible_os_family == "RedHat"
+#    - ansible_distribution_major_version == "8"
 
 - name: httpd variables
   set_fact:
@@ -125,9 +136,13 @@
   sefcontext:
     target: "/var/www/html(/.*)?"
     setype: httpd_sys_content_t
+  when:
+    - ansible_os_family == "RedHat"
 
 - name: "allow apache read-only access to /var/www/html"
   shell: 'restorecon -R -v /var/www/html'
+  when:
+    - ansible_os_family == "RedHat"
 
 - name: run handlers -- this runs the apache restart scripts
   meta: flush_handlers

--- a/tasks/dataverse-apache.yml
+++ b/tasks/dataverse-apache.yml
@@ -115,7 +115,9 @@
   notify: enable and restart apache
 
 - name: "both redhat and ubuntu default to /var/www/html"
-  shell: 'semanage fcontext -a -t httpd_sys_content_t "/var/www/html(/.*)?"'
+  sefcontext:
+    target: "/var/www/html(/.*)?"
+    setype: httpd_sys_content_t
 
 - name: "allow apache read-only access to /var/www/html"
   shell: 'restorecon -R -v /var/www/html'

--- a/tasks/dataverse-apache.yml
+++ b/tasks/dataverse-apache.yml
@@ -5,6 +5,12 @@
   debug:
     msg: '##### APACHE/HTTPD #####'
 
+- name: Install dependencies for SELinux modules
+  pip:
+    - libselinux-python
+    - policycoreutils-python
+
+# TODO: replace with ansible.posix.seboolean call
 - name: allow apache to make outbound connections
   shell: '/usr/sbin/setsebool -P httpd_can_network_connect 1'
   when:

--- a/tasks/dataverse-apache.yml
+++ b/tasks/dataverse-apache.yml
@@ -7,6 +7,7 @@
 
 - name: Install dependencies for SELinux modules
   pip:
+    name:
     - libselinux-python
     - policycoreutils-python
 

--- a/tasks/dataverse-apache.yml
+++ b/tasks/dataverse-apache.yml
@@ -33,7 +33,6 @@
     - httpd_read_user_content
   when:
     - ansible_os_family == "RedHat"
-#    - ansible_distribution_major_version == "8"
 
 - name: httpd variables
   set_fact:

--- a/tasks/dataverse-apache.yml
+++ b/tasks/dataverse-apache.yml
@@ -23,16 +23,11 @@
     - ansible_os_family == "RedHat"
     - ansible_distribution_major_version == "7"
 
-- name: set SELinux boolean
-  ansible.posix.seboolean:
-    name: "{{ item }}"
-    state: yes
-    persistent: yes
-  with_items:
-    - httpd_can_network_connect
-    - httpd_read_user_content
+- name: allow apache to read user content by default
+  shell: 'setsebool -P httpd_read_user_content 1'
   when:
     - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == "8"
 
 - name: httpd variables
   set_fact:


### PR DESCRIPTION
See #107 

107 was reversed because it introduced a dependency on the `ansible.posix` collection. I have now limited the change to replacing `shell: 'semanage fcontext -a -t httpd_sys_content_t "/var/www/html(/.*)?"'` with the use of the `sefcontext` Ansible module which solves the original problem, while not introducing the collection dependency.