### PR TITLE
plumb framework for building and deploying on Java 11

### DIFF
--- a/files/maven.sh
+++ b/files/maven.sh
@@ -1,0 +1,4 @@
+export JAVA_HOME=/usr/lib/jvm/jre-openjdk
+export M2_HOME=/opt/maven
+export MAVEN_HOME=/opt/maven
+export PATH=${M2_HOME}/bin:${PATH}

--- a/tasks/dataverse-build.yml
+++ b/tasks/dataverse-build.yml
@@ -4,21 +4,7 @@
   debug:
     msg: '##### BUILD WARFILE #####'
 
-- name: install maven
-  yum:
-    name: maven
-    state: latest
-
-- name: maven rpm requires openjdk-1.8 but maybe we want newer
-  alternatives:
-    name: '{{ item.name }}'
-    link: '{{ item.link }}'
-    path: '{{ item.path }}'
-  with_items:
-    - { name: 'java', link: '/usr/bin/java', path: '/usr/lib/jvm/java-{{ java.version }}-openjdk/bin/java'}
-    - { name: 'javac', link: '/usr/bin/javac', path: '/usr/lib/jvm/java-{{ java.version }}-openjdk/bin/javac'}
-  when: ansible_os_family == "RedHat" and
-        java.version != '1.8.0'
+- include: maven.yml
 
 - name: get branch_commit
   shell: 'cd "{{ dataverse.srcdir }}" && git log --oneline | head -1 | awk "{print $1}"'
@@ -40,17 +26,26 @@
     line: "build.number={{ dataverse_branch }}-{{ commit }}"
     create: yes
 
-- name: build warfile with default tests. tail /tmp/dataverse/mvn.out for gory details.
+- name: build warfile without tests. tail /tmp/dataverse/mvn.out for gory details.
   shell: "export JAVA_HOME=/usr/lib/jvm/java-{{ java.version}} && mvn -T 2C package -Dmaven.test.skip=true > mvn.out"
   args:
     chdir: "{{ dataverse.srcdir }}"
-  when: dataverse.unittests.enabled == false
+  when: dataverse.unittests.enabled == false and
+        maven.version == 'default'
 
 - name: build warfile with specified tests. tail /tmp/dataverse/mvn.out for gory details.
   shell: "mvn {{ dataverse.unittests.argument }} {{ jacoco_arg }} -T 2C package > mvn.out"
   args:
     chdir: "{{ dataverse.srcdir }}"
-  when: dataverse.unittests.enabled == true
+  when: dataverse.unittests.enabled == true and
+        maven.version == 'default'
+
+- name: build warfile with specified tests using custom maven. tail /tmp/dataverse/mvn.out for gory details.
+  shell: "source /etc/profile.d/maven.sh && mvn {{ dataverse.unittests.argument }} {{ jacoco_arg }} -T 2C package > mvn.out"
+  args:
+    chdir: "{{ dataverse.srcdir }}"
+  when: dataverse.unittests.enabled == true and
+        maven.version != 'default'
 
 - name: copy warfile over release
   copy:

--- a/tasks/maven.yml
+++ b/tasks/maven.yml
@@ -1,0 +1,34 @@
+---
+
+- name: install stock maven
+  package:
+    name: maven
+    state: latest
+  when: maven.version == 'default'
+
+- name: download custom maven version
+  get_url:
+    url: 'https://www-us.apache.org/dist/maven/maven-3/{{ maven.version }}/binaries/apache-maven-{{ maven.version }}-bin.tar.gz'
+    dest: '/tmp/apache-maven-{{ maven.version }}-bin.tar.gz'
+  when: maven.version != 'default'
+
+- name: maven dest dir must exist
+  file:
+    path: /opt/maven
+    owner: root
+    group: root
+    mode: 0755
+    state: directory
+
+- name: bsdtar so we get /opt/maven
+  shell: 'bsdtar --strip-components=1 -C /opt/maven -xf /tmp/apache-maven-{{ maven.version }}-bin.tar.gz'
+  when: maven.version != 'default'
+
+- name: place maven.sh profile config
+  copy:
+    src: maven.sh
+    dest: /etc/profile.d/maven.sh
+    owner: root
+    group: root
+    mode: 0755
+  when: maven.version != 'default'

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -208,6 +208,9 @@ localstack:
   hostname_external:
   web_ui: 8888
 
+maven:
+  version: default
+
 munin:
   install: false
   admin:

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -211,7 +211,7 @@ localstack:
   web_ui: 8888
 
 maven:
-  verion: default
+  version: default
 
 munin:
   install: false

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -210,6 +210,9 @@ localstack:
   hostname_external: 
   web_ui: 8888
 
+maven:
+  verion: default
+
 munin:
   install: false
   admin:

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -164,7 +164,7 @@ dataverse:
   srcdir: /tmp/dataverse
   thumbnails: false
   unittests:
-    enabled: false
+    enabled: true
     argument: '-DcompilerArgument=-Xlint:unchecked test -P all-unit-tests'
   usermgmtkey: burrito
   version: '5.3'
@@ -199,6 +199,9 @@ grafana:
 
 java:
   version: 1.8.0
+
+maven:
+  version: default
 
 munin:
   install: false


### PR DESCRIPTION
allows the installation of a custom `maven.version` ("3.6.3") in concert with switching `java.version` to 11 rather than installing CentOS' stock maven which is built against 1.8.

There are a few changes required in pom.xml (1.8 => 11, jacoco 0.8.6) so you'd want to run this against a branch, but... I think we're able to run a deployment against Java 11.

Currently there is one failing unit test:

```
[ERROR] StorageIOTest.testGetDvObject:72 expected:<[class edu.harvard.iq.dataverse.Dataset cannot be cast to class edu.harvard.iq.dataverse.DataFile (edu.harvard.iq.dataverse.Dataset and edu.harvard.iq.dataverse.DataFile are in unnamed module of loader 'app')]> but was:<[edu.harvard.iq.dataverse.Dataset cannot be cast to edu.harvard.iq.dataverse.DataFile]>
```