### PR TITLE
Added variable for alternative dataverse installer location

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,8 @@
 # un-nested so we can pass them at the CLI
 dataverse_branch: release
 dataverse_repo: https://github.com/IQSS/dataverse.git
+# To use a dvinstall.zip from a different location than IQSS:
+# dataverse_installer_url: https://example.com/path/to/dvinstall.zip
 
 apache:
   ssl:

--- a/tasks/dataverse-download.yml
+++ b/tasks/dataverse-download.yml
@@ -4,6 +4,13 @@
   get_url:
     url: https://github.com/IQSS/dataverse/releases/download/v{{ dataverse.version }}/dvinstall.zip
     dest: /tmp
+  when: dataverse_installer_url is not defined
+
+- name: download alternative dataverse installer
+  get_url:
+    url: '{{ dataverse_installer_url }}'
+    dest: /tmp
+  when: dataverse_installer_url is defined
 
 - name: unzip dataverse installer
   unarchive:

--- a/tasks/dataverse-get-release.yml
+++ b/tasks/dataverse-get-release.yml
@@ -8,6 +8,13 @@
   get_url:
     url: https://github.com/IQSS/dataverse/releases/download/v{{ dataverse.version }}/dvinstall.zip
     dest: /tmp
+  when: dataverse_installer_url is not defined
+
+- name: download alternative dataverse installer
+  get_url:
+    url: '{{ dataverse_installer_url }}'
+    dest: /tmp
+  when: dataverse_installer_url is defined
 
 - name: unzip dataverse installer
   unarchive:


### PR DESCRIPTION
This PR adds an optional variable `dataverse_installer_url` which, if set, is used as the URL from where to download the `dvinstall.zip`. This is very useful for testing code that is still in review but cannot be tested by simply redeploying `dataverse.war`, for example because it contain database changes. 
