### PR TITLE
Update url for Previewers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -137,7 +137,7 @@ dataverse:
   previewers:
     enabled: true
     on_same_server: true
-    zip_url: https://github.com/GlobalDataverseCommunityConsortium/dataverse-previewers/archive/1.1.zip
+    zip_url: https://github.com/GlobalDataverseCommunityConsortium/dataverse-previewers/archive/1.1.1.zip
     dir: /var/www/html
   sampledata:
     enabled: false


### PR DESCRIPTION
Updates the `url` for `Dataverse previewers`.  Version v1.1.1 contains the fix for datafile description field vulnerability.``