### PR TITLE
differentiate PowerTools from powertools

### DIFF
--- a/tasks/rserve.yml
+++ b/tasks/rserve.yml
@@ -16,10 +16,16 @@
   when: ansible_distribution == "RedHat" and
         ansible_distribution_major_version == "8"
 
-- name: CentOS8 needs PowerTools
+- name: CentOS 8.2 in EC2 needs PowerTools
   shell: "dnf config-manager --enable PowerTools"
   when: ansible_distribution == "CentOS" and
-        ansible_distribution_major_version == "8"
+        ansible_distribution_version == "8.2"
+
+- name: CentOS 8.3 and Stream need powertools
+  shell: "dnf config-manager --enable powertools"
+  when: ansible_distribution == "CentOS" and
+        ansible_distribution_major_version == "8" and
+        ansible_distribution_version != "8.2"
 
 - name: install base packages
   yum:


### PR DESCRIPTION
CentOS 8.2 wants `PowerTools` for R; CentOS 8.3 and 8-Stream want `powertools`

This case wouldn't catch CentOS 8.[0-1] but... I plan to switch to Rocky Linux once it's available.