### PR TITLE
correct vagrant.yml reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ It is possible to run certain portions of the playbook to avoid running the enti
 	$ cd dataverse-ansible
 	$ vagrant up
 
-On successful completion of the Vagrant run, you should be able to log in to your test Dataverse as dataverseAdmin using the dataverse_adminpass from group_vars/vagrant.vars using the address:
+On successful completion of the Vagrant run, you should be able to log in to your test Dataverse as dataverseAdmin using the dataverse_adminpass from tests/group_vars/vagrant.yml using the address:
 
 	http://localhost
 


### PR DESCRIPTION
Closes #154 

@vkush thank you for catching this! Yes, some of the vars having differing values, and while some of the true/false conditions have reasons for being so depending on where the test may be run (Vagrant vs. Jenkins vs. bare metal) the username/password combinations in particular are merely examples and are expected to be changed by any user of the role.