### PR TITLE
allow cors step bypass

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -247,6 +247,7 @@ s3:
   access_key: 4cc355_k3y
   secret_access_key: s3cr3t_4cc355_k3y
   bucket_name: s3-test
+  cors_already_set: false
   create_bucket: true
   # for non-amazon services. for localstack, you might set
   #custom_endpoint_url: "http://localhost:4572"

--- a/tasks/s3.yml
+++ b/tasks/s3.yml
@@ -91,7 +91,7 @@
     PATH: "{{ lookup('env', 'PATH') }}:/usr/local/bin"
   when: (s3.download_redirect == true or s3.upload_redirect == true)
     and custom_endpoint_url | length == 0
-    and s3.cors_already_set = false
+    and s3.cors_already_set == false
 
 - include: s3_custom_endpoint_url.yml
   when: custom_endpoint_url | length > 0

--- a/tasks/s3.yml
+++ b/tasks/s3.yml
@@ -77,8 +77,7 @@
     owner: '{{ dataverse.payara.user }}'
     group: '{{ dataverse.payara.group }}'
     mode: 0644
-  when: (s3.download_redirect == true
-    or s3.upload_redirect == true)
+  when: (s3.download_redirect == true or s3.upload_redirect == true)
     and s3.cors_already_set == false
 
 - name: enable CORS on S3 bucket
@@ -90,8 +89,7 @@
   become_user: '{{ dataverse.payara.user }}'
   environment:
     PATH: "{{ lookup('env', 'PATH') }}:/usr/local/bin"
-  when: (s3.download_redirect == true
-    or s3.upload_redirect == true)
+  when: (s3.download_redirect == true or s3.upload_redirect == true)
     and custom_endpoint_url | length == 0
     and cors_already_set = false
 

--- a/tasks/s3.yml
+++ b/tasks/s3.yml
@@ -77,8 +77,9 @@
     owner: '{{ dataverse.payara.user }}'
     group: '{{ dataverse.payara.group }}'
     mode: 0644
-  when: s3.download_redirect == true or
-    s3.upload_redirect == true
+  when: (s3.download_redirect == true
+    or s3.upload_redirect == true)
+    and s3.cors_already_set == false
 
 - name: enable CORS on S3 bucket
   shell:
@@ -89,9 +90,10 @@
   become_user: '{{ dataverse.payara.user }}'
   environment:
     PATH: "{{ lookup('env', 'PATH') }}:/usr/local/bin"
-  when: (s3.download_redirect == true or
-    s3.upload_redirect == true)
+  when: (s3.download_redirect == true
+    or s3.upload_redirect == true)
     and custom_endpoint_url | length == 0
+    and cors_already_set = false
 
 - include: s3_custom_endpoint_url.yml
   when: custom_endpoint_url | length > 0

--- a/tasks/s3.yml
+++ b/tasks/s3.yml
@@ -91,7 +91,7 @@
     PATH: "{{ lookup('env', 'PATH') }}:/usr/local/bin"
   when: (s3.download_redirect == true or s3.upload_redirect == true)
     and custom_endpoint_url | length == 0
-    and cors_already_set = false
+    and s3.cors_already_set = false
 
 - include: s3_custom_endpoint_url.yml
   when: custom_endpoint_url | length > 0

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -241,6 +241,7 @@ s3:
   access_key: 4cc355_k3y
   secret_access_key: s3cr3t_4cc355_k3y
   bucket_name: s3-test
+  cors_already_set: false
   create_bucket: true
   # for non-amazon services.
   custom_endpoint_url: "http://localhost:4572"

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -243,6 +243,7 @@ s3:
   access_key: 4cc355_k3y
   secret_access_key: s3cr3t_4cc355_k3y
   bucket_name: s3-test
+  cors_already_set: false
   create_bucket: true
   # for non-amazon services.
   custom_endpoint_url: "http://localhost:4572"

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -234,6 +234,7 @@ s3:
   secret_access_key: s3cr3t_4cc355_k3y
   bucket_name: s3-test
   create_bucket: true
+  cors_already_set: false
   # for non-amazon services. for localstack, you might set
   #custom_endpoint_url: "http://localhost:4572"
   custom_endpoint_url:


### PR DESCRIPTION
Closes #163 

For AWS users who don't have PutBucketCORS permission, but whose target bucket already allows CORS, don't attempt to set CORS policy when `s3.cors_already_enabled == true`

Jenkins tests don't use S3 and therefore bypass these changes:
<img width="457" alt="Screen Shot 2021-07-28 at 14 33 20" src="https://user-images.githubusercontent.com/12831666/127383568-4a9b2069-1387-42c8-97f5-39a24a97e3d4.png">
