### PR TITLE
Set the owner of the branding files to dataverse (instead of root)

### DIFF
--- a/tasks/dataverse-gui.yml
+++ b/tasks/dataverse-gui.yml
@@ -17,16 +17,16 @@
     src: '{{ item }}'
     dest: '{{ favicon_file_path }}'
     mode: '0644'
-    owner: dataverse
-    group: dataverse
+    owner: '{{ dataverse.payara.user }}'
+    group: '{{ dataverse.payara.group }}'
   with_fileglob: '{{ dataverse.branding.favicons_directory }}/*.ico'
 
 - name: copy branding files
   copy:
     src: branding
     dest: '{{ gui_file_path }}'
-    owner: dataverse
-    group: dataverse
+    owner: '{{ dataverse.payara.user }}'
+    group: '{{ dataverse.payara.group }}'
     mode: '0644'
 
 - name: Update branding file settings on server

--- a/tasks/dataverse-gui.yml
+++ b/tasks/dataverse-gui.yml
@@ -17,12 +17,16 @@
     src: '{{ item }}'
     dest: '{{ favicon_file_path }}'
     mode: '0644'
+    owner: dataverse
+    group: dataverse
   with_fileglob: '{{ dataverse.branding.favicons_directory }}/*.ico'
 
 - name: copy branding files
   copy:
     src: branding
     dest: '{{ gui_file_path }}'
+    owner: dataverse
+    group: dataverse
     mode: '0644'
 
 - name: Update branding file settings on server


### PR DESCRIPTION
Currently the custom branding files are copied by root into the application deployment directory of Dataverse at `payara5/glassfish/domains/domain1/applications/dataverse/`. They end up owned by root. The `dataverse` user cannot modify or remove them, even though they are in a Payara managed directory. 

