### PR TITLE
Restore ignore errors when stopping payara domain.

### DIFF
--- a/tasks/dataverse-install.yml
+++ b/tasks/dataverse-install.yml
@@ -136,7 +136,7 @@
   become: yes
   become_user: "{{ dataverse.payara.user }}"
   shell: '{{ payara_dir }}/bin/asadmin stop-domain {{ dataverse.payara.domain }}'
-  #ignore_errors: yes
+  ignore_errors: yes
 
 - name: now start payara with systemd
   service:


### PR DESCRIPTION
I don't know why it was removed, but I understand why it was put there originally: when we run `dataverse-ansible` this task consistently fails. This failure, when ignored, does not have any adverse effect on the rest of the role execution. 