### PR TITLE
fatal error many make

### DIFF
--- a/dataverse.pb
+++ b/dataverse.pb
@@ -3,6 +3,7 @@
 
 - name: Install Dataverse
   hosts: dataverse
+  any_errors_fatal: '{{ any_errors_fatal }}'
   become: true
   roles:
     - role: dataverse

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ dataverse_repo: https://github.com/IQSS/dataverse.git
 # To use a dvinstall.zip from a different location than IQSS:
 # dataverse_installer_url: https://example.com/path/to/dvinstall.zip
 
+# set this to true for troubleshooting
+any_errors_fatal: false
+
 apache:
   ssl:
     enabled: false

--- a/ec2/ec2-create-instance.sh
+++ b/ec2/ec2-create-instance.sh
@@ -232,7 +232,6 @@ sudo yum -q -y install ansible git nano
 git clone -b $DA_BRANCH https://github.com/GlobalDataverseCommunityConsortium/dataverse-ansible.git dataverse
 export ANSIBLE_ROLES_PATH=.
 ansible-playbook $VERBOSE_ARG -i dataverse/inventory dataverse/dataverse.pb --connection=local $GVARG
-touch /tmp/ansible_complete
 EOF
 
 # did AWS go AWOL? Jenkins will check for this file.

--- a/tasks/fin.yml
+++ b/tasks/fin.yml
@@ -1,0 +1,13 @@
+---
+
+- name: touch semaphore for Jenkins
+  file:
+    path: /tmp/ansible_complete
+    owner: root
+    group: root
+    mode: 0644
+    state: touch
+
+- name: Fin
+  debug:
+    msg: '##### END ANSIBLE ROLE #####'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -169,6 +169,5 @@
   tags:
   - schemaspy
 
-- name: Fin
-  debug:
-    msg: '##### END ANSIBLE ROLE #####'
+- include: fin.yml
+  

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -278,3 +278,4 @@ sshkeys:
 
 dataverse_branch: develop
 dataverse_repo: https://github.com/IQSS/dataverse.git
+any_errors_fatal: true

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -4,6 +4,7 @@
 # un-nested so we can pass them at the CLI
 dataverse_branch: release
 dataverse_repo: https://github.com/IQSS/dataverse.git
+any_errors_fatal: false
 
 apache:
   ssl:

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -4,6 +4,7 @@
 # un-nested so we can pass them at the CLI
 dataverse_branch: release
 dataverse_repo: https://github.com/IQSS/dataverse.git
+any_errors_fatal: true
 
 apache:
   ssl:


### PR DESCRIPTION
add `any_errors_fatal` flag, off or on by default depending on platform, and mv ansible_complete semaphore inside ansible role instead of ec2-create script.

doesn't seem to trigger the stop-Payara error @janvanmansum is hitting on Debian (and will remain set to false in defaults.yml)