### PR TITLE
Replace updateSchemaMDB.sh with update-fields.sh

### DIFF
--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -51,7 +51,7 @@
 - name: update custom metadata blocks
   shell: '/tmp/dvinstall/update-fields.sh {{ dataverse.solr.root }}/server/solr/collection1/conf/schema.xml'
   args:
-    stdin: '{{ current_schema }}'
+    stdin: '{{ current_schema.content }}'
   become: yes
   become_user: '{{ dataverse.solr.user }}'
   when: dataverse.custom_metadata_blocks.enabled == True

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -42,8 +42,15 @@
   loop: '{{ custom_metadata_block_list.files }}'
   when: dataverse.custom_metadata_blocks.enabled == True
 
+- name: read current solr schema
+  uri:
+    url: http://localhost:8080/api/admin/index/solr/schema
+    return_content: yes
+  register: current_schema
+
 - name: update custom metadata blocks
-  shell: '/tmp/dvinstall/updateSchemaMDB.sh -t {{ dataverse.solr.root }}/server/solr/collection1/conf'
+  shell: '/tmp/dvinstall/update-fields.sh {{ dataverse.solr.root }}/server/solr/collection1/conf/schema.xml'
+  stdin: '{{ current_schema }}'
   become: yes
   become_user: '{{ dataverse.solr.user }}'
   when: dataverse.custom_metadata_blocks.enabled == True

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -50,7 +50,7 @@
 
 - name: update custom metadata blocks
   shell: '/tmp/dvinstall/update-fields.sh {{ dataverse.solr.root }}/server/solr/collection1/conf/schema.xml'
-  stdin: '{{ current_schema }}'
+    stdin: '{{ current_schema }}'
   become: yes
   become_user: '{{ dataverse.solr.user }}'
   when: dataverse.custom_metadata_blocks.enabled == True

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -50,6 +50,7 @@
 
 - name: update custom metadata blocks
   shell: '/tmp/dvinstall/update-fields.sh {{ dataverse.solr.root }}/server/solr/collection1/conf/schema.xml'
+  args:
     stdin: '{{ current_schema }}'
   become: yes
   become_user: '{{ dataverse.solr.user }}'


### PR DESCRIPTION
In v5.8 of Dataverse `updateSchemaMDB.sh` has been replaced with `update-fields.sh`. The new script has a slightly different command line interface.