### PR TITLE
Shibboleth now offers a Rocky repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -281,7 +281,6 @@ schemaspy:
 
 shibboleth:
   enabled: false
-  repo: "http://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/security:shibboleth.repo"
   email: TODO
   organizationName: TODO
   organizationalUnitName: TODO

--- a/files/shibboleth.centos8.repo
+++ b/files/shibboleth.centos8.repo
@@ -1,0 +1,9 @@
+[shibboleth]
+name=Shibboleth (CentOS_8)
+# Please report any problems to https://shibboleth.atlassian.net/jira
+type=rpm-md
+mirrorlist=https://shibboleth.net/cgi-bin/mirrorlist.cgi/CentOS_8
+gpgcheck=1
+gpgkey=https://shibboleth.net/downloads/service-provider/RPMS/repomd.xml.key
+        https://shibboleth.net/downloads/service-provider/RPMS/cantor.repomd.xml.key
+enabled=1

--- a/files/shibboleth.rocky8.repo
+++ b/files/shibboleth.rocky8.repo
@@ -1,0 +1,9 @@
+[shibboleth]
+name=Shibboleth (rockylinux8)
+# Please report any problems to https://shibboleth.atlassian.net/jira
+type=rpm-md
+mirrorlist=https://shibboleth.net/cgi-bin/mirrorlist.cgi/rockylinux8
+gpgcheck=1
+gpgkey=https://shibboleth.net/downloads/service-provider/RPMS/repomd.xml.key
+        https://shibboleth.net/downloads/service-provider/RPMS/cantor.repomd.xml.key
+enabled=1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,7 +102,7 @@
   - gui
   when: dataverse.branding.enabled
 
-- include: dataverse-shibboleth.yml
+- include: shibboleth.yml
   when: shibboleth.enabled == True
   tags:
   - shibboleth

--- a/tasks/shibboleth.yml
+++ b/tasks/shibboleth.yml
@@ -18,7 +18,17 @@
     mode: 0644
   when: ansible_distribution == "Rocky"
 
-- name: install Shibboleth RPMs for RedHat/Rocky
+- name: install shibboleth repo for RHEL/CentOS 8
+  ansible.builtin.copy:
+    src: 'shibboleth.centos8.repo'
+    dest: /etc/yum.repos.d/shibboleth.repo
+    owner: root
+    group: root
+    mode: 0644
+  when: (ansible_distribution == "RedHat" and ansible_distribution_major_version == "8")
+     or (ansible_distribution == "CentOS" and ansible_distribution_major_version == "8")
+
+- name: install Shibboleth RPMs for RHEL and derivatives
   ansible.builtin.package:
     name: shibboleth
     state: latest

--- a/tasks/shibboleth.yml
+++ b/tasks/shibboleth.yml
@@ -9,13 +9,17 @@
   set_fact:
     shibboleth_user: "{{ (ansible_os_family == 'RedHat') | ternary ('shibd', '_shibd') }}"
 
-- name: install shibboleth repo for RedHat/CentOS7
-  get_url: url={{ shibboleth.repo }} dest=/etc/yum.repos.d
-        owner=root group=root mode=0644
-  when: ansible_os_family == "RedHat"
+- name: install shibboleth repo for Rocky 8
+  ansible.builtin.copy:
+    src: 'shibboleth.rocky8.repo'
+    dest: /etc/yum.repos.d/shibboleth.repo
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_distribution == "Rocky"
 
-- name: install Shibboleth RPMs for RedHat/CentOS7
-  yum:
+- name: install Shibboleth RPMs for RedHat/Rocky
+  ansible.builtin.package:
     name: shibboleth
     state: latest
   when: ansible_os_family == "RedHat"

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -271,7 +271,6 @@ schemaspy:
 
 shibboleth:
   enabled: false
-  repo: "http://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/security:shibboleth.repo"
 
 sshkeys:
   enabled: false

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -273,7 +273,6 @@ schemaspy:
 
 shibboleth:
   enabled: false
-  repo: "http://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/security:shibboleth.repo"
   email: TODO
   organizationName: TODO
   organizationalUnitName: TODO

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -265,7 +265,6 @@ schemaspy:
 
 shibboleth:
   enabled: false
-  repo: "http://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/security:shibboleth.repo"
 
 sshkeys:
   enabled: false


### PR DESCRIPTION
Closes #189 

They recommend we not use the OpenSUSE packages; their web-form generates a copy-paste-able yum/dnf repo, so that's what I dropped in place.

I can add other distro cases on demand, though I don't really see many folks installing Shibboleth via dataverse-ansible.