### PR TITLE
update references to CentOS8 to Rocky8 where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Here is an example of how to execute the `dataverse-ansible` role with more adju
 | -e     | Extra variables file                  | no       |
 | -v     | run with Verbosity (up to three Vs)   | no       |
 
-The role currently supports CentOS 7 and 8 with all services running on the same machine, but intends to become OS-agnostic and support multiple nodes for scalability.
+The role currently supports RHEL/CentOS 7, RHEL/Rocky 8 and Debian 11 with all services running on the same machine, but intends to become OS-agnostic and support multiple nodes for scalability.
 
 If you're interested in testing Dataverse locally using [Vagrant][vagrant], you'll want to clone this repository and edit the local port redirects if the http/https ports on your local machine are already in use. Note that the current Vagrant VM template requires [VirtualBox][virtualbox] 5.0+ and will automatically launch the above command within your Vagrant VM.
 
@@ -114,7 +114,7 @@ If you needed to update the host port in the Vagrantfile due to collision, you'd
 * Postgres (database)
   * Default data/config location: */var/lib/pgsql/9.6/data/*
   * `$ systemctl {start|stop|restart|status} postgresql-9.6`
-  * **Note:** as of this writing, RHEL/CentOS8 are compiled- and will only work with PostgresQL 10+
+  * **Note:** as of this writing, RHEL/Rocky8 are compiled- and will only work with PostgresQL 10+
 * Shibboleth
   * Provides an additional authentication provider.
   * Default config location: */etc/shibboleth/shibboleth2.xml*

--- a/ec2/README.md
+++ b/ec2/README.md
@@ -18,7 +18,7 @@ An existing AWS **security group** to allow network access, typically ports 22, 
 * the default repo is `https://github.com/IQSS/dataverse`
 * the default .pem location is the user home directory
 * example group_vars may be retrieved from [https://raw.githubusercontent.com/GlobalDataverseCommunityConsortium/dataverse-ansible/master/defaults/main.yml](https://raw.githubusercontent.com/GlobalDataverseCommunityConsortium/dataverse-ansible/master/defaults/main.yml)
-* the default AWS AMI ID is ami-01ca03df4a6012157 *(CentOS 8 in us-east-1)*
+* the default AWS AMI ID is ami-043ceee68871e0bb5 *(Rocky 8 in us-east-1)* ; full list at https://rockylinux.org/ami/
 * the default AWS size is t2.xlarge to avoid OoM killer during integration tests (otherwise, t2.large or even t2.medium may be fine)
 * local log path will rsync Payara, Jacoco, Maven and other logs back to the specified path
 * `-d` will destroy (terminate) the AWS instance once testing, reporting, and log-copying completes

--- a/ec2/ec2-create-instance.sh
+++ b/ec2/ec2-create-instance.sh
@@ -8,11 +8,8 @@ BRANCH_DEFAULT="develop"
 PEM_DEFAULT=${HOME}
 VERBOSE_ARG=""
 
-# centos image list at https://wiki.centos.org/Cloud/AWS
-# centos 7
-#AWS_AMI_DEFAULT='ami-9887c6e7'
-# rocky linux 8.4 official, us-east-1
-AWS_AMI_DEFAULT='ami-02628ddf3745c6dda'
+# rocky linux 8.5 official, us-east-1
+AWS_AMI_DEFAULT='ami-043ceee68871e0bb5'
 
 usage() {
   echo "Usage: $0 -b <branch> -r <repo> -p <pem_path> -g <group_vars> -a <dataverse-ansible branch> -i aws_image -u aws_user -s aws_size -t aws_tag -f aws_security group -l local_log_path -d -v" 1>&2
@@ -20,7 +17,7 @@ usage() {
   echo "default repo is https://github.com/IQSS/dataverse"
   echo "default .pem location is ${HOME}"
   echo "example group_vars may be retrieved from https://raw.githubusercontent.com/GlobalDataverseCommunityConsortium/dataverse-ansible/develop/defaults/main.yml"
-  echo "default AWS AMI ID is $AWS_AMI_DEFAULT, find the full list at https://wiki.centos.org/Cloud/AWS"
+  echo "default AWS AMI ID is $AWS_AMI_DEFAULT, find the full list at https://rockylinux.org/ami/"
   echo "default AWS user is rocky"
   echo "default AWS instance size is t3a.large"
   echo "default AWS security group is dataverse-sg"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: enable and restart httpd on RedHat/CentOS
+- name: enable and restart httpd on RedHat/Rocky
   service: name=httpd enabled=yes state=restarted
   when:
    - ansible_os_family == "RedHat"
@@ -14,7 +14,7 @@
 - name: enable and restart shibd
   service: name=shibd enabled=yes state=restarted
 
-- name: enable and start postgres on RHEL/CentOS
+- name: enable and start postgres on RHEL/Rocky
   service:
     name: 'postgresql-{{ db.postgres.version }}'
     state: restarted

--- a/tasks/build_guides.yml
+++ b/tasks/build_guides.yml
@@ -1,8 +1,8 @@
 ---
 
-- name: CentOS8 needs PowerTools
-  shell: "dnf config-manager --enable PowerTools"
-  when: ansible_distribution == "CentOS" and
+- name: Rocky needs powertools
+  shell: "dnf config-manager --enable powertools"
+  when: ansible_distribution == "Rocky" and
         ansible_distribution_major_version == "8"
 
 - name: install build prerequisites

--- a/tasks/dataverse-apache.yml
+++ b/tasks/dataverse-apache.yml
@@ -9,7 +9,7 @@
   set_fact:
     apache_config_base_dir: "{{ (ansible_os_family == 'RedHat') | ternary ('/etc/httpd', '/etc/apache2') }}"
 
-- name: httpd variables for RedHat/CentOS
+- name: httpd variables for RedHat/Rocky
   set_fact:
     apache_virtualhost_dir: "{{ apache_config_base_dir }}/conf.d"
     apache_config_dir: "{{ apache_config_base_dir }}/conf.d"
@@ -21,7 +21,7 @@
     apache_config_dir: "{{ apache_config_base_dir }}/conf-enabled"
   when: ansible_os_family == "Debian"
 
-- name: install Apache for RedHat/CentOS
+- name: install Apache for RedHat/Rocky
   yum: 
     name: ['httpd', 'mod_ssl']
     state: latest
@@ -102,7 +102,7 @@
     mode: 0644
   notify: enable and restart apache
 
-- name: this package provides semanage on CentOS 8.3-minimal
+- name: this package provides semanage on RHEL / Rocky 8
   package:
     name: policycoreutils-python-utils
     state: latest

--- a/tasks/dataverse-prereqs.yml
+++ b/tasks/dataverse-prereqs.yml
@@ -9,7 +9,7 @@
   shell: 'yum clean all'
   when: ansible_os_family == "RedHat"
 
-- name: let's use the closest centos mirror
+- name: let's use the closest mirror
   file:
     path: /var/cache/yum/x86_64/7/timedhosts.txt
     state: absent
@@ -35,7 +35,7 @@
     update_cache: yes
   when: ansible_os_family == "Debian"
 
-- name: ensure EPEL repository for RedHat7/CentOS7
+- name: ensure EPEL repository for RedHat/Rocky
   yum:
     name: epel-release
     state: latest
@@ -45,7 +45,7 @@
   package:
     name: bash-completion, git, jq, mlocate, net-tools, sudo, unzip, python3-psycopg2
 
-- name: install java-nnn-openjdk and other packages for RedHat/CentOS.
+- name: install java-nnn-openjdk and other packages for RedHat/Rocky
   yum:
     name: ['java-{{ java.version }}-openjdk-devel', 'python36', 'vim-enhanced']
     state: latest
@@ -57,7 +57,7 @@
   when: ansible_os_family == "Debian"
 
 # it is strongly recommended to check for open CVEs before enabling this.
-- name: install GraphicsMagic on RHEL/CentOS8 for thumbnail generation
+- name: install GraphicsMagic on RHEL/Rocky for thumbnail generation
   dnf:
     name: GraphicsMagick
   when:

--- a/tasks/dataverse-shibboleth.yml
+++ b/tasks/dataverse-shibboleth.yml
@@ -9,12 +9,12 @@
   set_fact:
     shibboleth_user: "{{ (ansible_os_family == 'RedHat') | ternary ('shibd', '_shibd') }}"
 
-- name: install shibboleth repo for RedHat/CentOS7
+- name: install shibboleth repo for RedHat/Rocky
   get_url: url={{ shibboleth.repo }} dest=/etc/yum.repos.d
         owner=root group=root mode=0644
   when: ansible_os_family == "RedHat"
 
-- name: install Shibboleth RPMs for RedHat/CentOS7
+- name: install Shibboleth RPMs for RedHat/Rocky
   yum:
     name: shibboleth
     state: latest

--- a/tasks/payara.yml
+++ b/tasks/payara.yml
@@ -120,7 +120,7 @@
     - { user: "{{ dataverse.payara.user }}", type: hard, descriptor: nofile, value: 65000 }
   notify: enable and restart payara
 
-- name: install payara systemd conf file for RedHat / CentOS7
+- name: install payara systemd conf file for RHEL/Rocky
   template: src=payara.service.j2 dest=/usr/lib/systemd/system/payara.service
         owner=root group=root mode=0644
   when: ansible_os_family == "RedHat"

--- a/tasks/postgres.yml
+++ b/tasks/postgres.yml
@@ -33,7 +33,7 @@
     state: present
   when: ansible_os_family == "RedHat"
 
-- name: "rhel/centos8: disable postgresql proper in the OS"
+- name: "RHEL/Rocky8: disable PostgreSQL proper in the OS"
   shell: 'dnf -qy module disable postgresql'
   when: ansible_os_family == "RedHat" and
         ansible_distribution_major_version == "8"
@@ -42,7 +42,7 @@
   set_fact:
     dataverse_pg_version_short: "{{ db.postgres.version | regex_replace('\\.','') }}"
 
-- name: install postgres server on RedHat / CentOS
+- name: install postgres server on RedHat / Rocky
   yum:
    name: 'postgresql{{ dataverse_pg_version_short }}-server'
    state: latest
@@ -56,7 +56,7 @@
   when: ansible_os_family == "Debian" and
         db.use_rds == false
 
-- name: install postgres client on RedHat / CentOS for RDS
+- name: install postgres client on RedHat / Rocky for RDS
   yum:
     name: 'postgresql{{ dataverse_pg_version_short }}'
     state: latest
@@ -73,7 +73,7 @@
 - include: postgresql-init.yml
   when: db.use_rds == false
 
-- name: install pg_hba.conf on RHEL/CentOS
+- name: install pg_hba.conf on RHEL/Rocky
   copy:
     src: pg_hba.conf
     dest: '/var/lib/pgsql/{{ db.postgres.version }}/data'

--- a/tasks/postgresql-init.yml
+++ b/tasks/postgresql-init.yml
@@ -20,7 +20,7 @@
   register: postgres_initdb
   when: db.use_rds == false
 
-- name: init postgres on RHEL/CentOS
+- name: init postgres on RHEL/Rocky
   shell: '{{ postgres_init }}'
   when: postgres_initdb.stat.exists == false and
         db.use_rds == false and

--- a/tasks/rserve.yml
+++ b/tasks/rserve.yml
@@ -16,17 +16,6 @@
   when: ansible_distribution == "RedHat" and
         ansible_distribution_major_version == "8"
 
-- name: CentOS 8.2 in EC2 needs PowerTools
-  shell: "dnf config-manager --enable PowerTools"
-  when: ansible_distribution == "CentOS" and
-        ansible_distribution_version == "8.2"
-
-- name: CentOS 8.3 and Stream need powertools
-  shell: "dnf config-manager --enable powertools"
-  when: ansible_distribution == "CentOS" and
-        ansible_distribution_major_version == "8" and
-        ansible_distribution_version != "8.2"
-
 - name: Rocky needs powertools
   shell: "dnf config-manager --enable powertools"
   when: ansible_distribution == "Rocky" and

--- a/tasks/solr.yml
+++ b/tasks/solr.yml
@@ -5,11 +5,11 @@
   debug:
     msg: '##### SOLR #####'
 
-- name: ensure EPEL repository for RedHat/CentOS 7
+- name: ensure EPEL repository for RedHat/Rocky
   yum: name=epel-release state=latest
   when: ansible_os_family == "RedHat"
 
-- name: install Solr pre-reqs for RedHat/CentOS 7
+- name: install Solr pre-reqs for RedHat/Rocky
   yum:
     name: ['java-{{ java.version }}-openjdk-devel', 'lsof']
     state: latest
@@ -161,7 +161,7 @@
   copy: src=solr.conf dest=/etc/init owner=root group=root mode=0644
   when: ansible_os_family == "Debian"
 
-- name: install solr systemd conf file for RedHat/CentOS
+- name: install solr systemd conf file for RedHat/Rocky
   template: src=solr.service.j2 dest=/usr/lib/systemd/system/solr.service
         owner=root group=root mode=0644
   when: ansible_os_family == "RedHat"

--- a/tasks/sshkeys.yml
+++ b/tasks/sshkeys.yml
@@ -18,7 +18,7 @@
 - set_fact:
     is_aws_environment: "{{ aws_uri_check.status == 200 }}"
 
-- name: if we're in EC2, default to centos user
+- name: if we're in EC2, default to instance user
   set_fact: sshkeys_user='{{ sshkeys.user }}'
   when: is_aws_environment and
         sshkeys_user | length < 1

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,16 +1,17 @@
-FROM centos:7
+FROM rockylinux:8
 
-# Install systemd -- See https://hub.docker.com/_/centos/
-RUN yum -y swap -- remove fakesystemd -- install systemd systemd-libs
-RUN yum -y update; yum clean all; \
-    (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-    rm -f /lib/systemd/system/multi-user.target.wants/*; \
-    rm -f /etc/systemd/system/*.wants/*; \
-    rm -f /lib/systemd/system/local-fs.target.wants/*; \
-    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
-    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
-    rm -f /lib/systemd/system/basic.target.wants/*; \
-    rm -f /lib/systemd/system/anaconda.target.wants/*;
+ENV container docker
+
+# systemd funsies per https://hub.docker.com/r/rockylinux/rockylinux
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 # Install Ansible and some dependencies
 RUN yum update -y \


### PR DESCRIPTION
Closes #192 

and bump the default EC2 AMI to Rocky-8.5 while we're at it.