### PR TITLE
remove JMSAppender.class from bundled log4j-v1 for good measure

### DIFF
--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -55,6 +55,23 @@
     mode: 0644
   when: dataverse.payara.zipurl is match(".*payara-5.2021.5.zip")
 
+- name: find bundled log4j-v1 beneath applications
+  ansible.builtin.find:
+    paths: '{{ payara_dir }}/glassfish/domains/{{ dataverse.payara.domain }}/applications/'
+    patterns: 'log4j-1.2*'
+    file_type: file
+    recurse: yes
+    use_regex: yes
+  register: log4jv1_list
+
+- name: remove JMSAppender from bundled log4j
+  ansible.builtin.shell:
+    cmd: 'zip -q -d {{ item }} org/apache/log4j/net/JMSAppender.class'
+  become: yes
+  become_user: '{{ dataverse.payara.user }}'
+  with_items:
+  - "{{ log4jv1_list.files | map(attribute='path') | list }}"
+
 - name: start payara
   service:
     name: payara

--- a/tasks/dataverse-prereqs.yml
+++ b/tasks/dataverse-prereqs.yml
@@ -41,9 +41,10 @@
     state: latest
   when: ansible_os_family == "RedHat"
 
-- name: install various packages
-  package:
-    name: bash-completion, git, jq, mlocate, net-tools, sudo, unzip, python3-psycopg2
+- name: install some necessary packages
+  ansible.builtin.package:
+    name: ['bash-completion', 'git', 'jq', 'mlocate', 'net-tools', 'sudo', 'unzip', 'python3-psycopg2', 'zip']
+    state: latest
 
 - name: install java-nnn-openjdk and other packages for RedHat/Rocky
   yum:


### PR DESCRIPTION
Dataverse isn't configured to use JMSAppender so this isn't strictly necessary, but it would protect Dataverse from CVE-2021-4104