### PR TITLE
Make Apache configuration optional + small fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ dataverse_repo: https://github.com/IQSS/dataverse.git
 any_errors_fatal: false
 
 apache:
+  enabled: true
   ssl:
     enabled: false
     remote_cert: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,7 @@
   - postfix
 
 - include: dataverse-apache.yml
+  when: apache.enabled == True
   tags:
   - apache
 

--- a/templates/http.proxy.conf.j2
+++ b/templates/http.proxy.conf.j2
@@ -1,7 +1,7 @@
 {% if apache.ssl.enabled %}
 <IfModule ssl_module>
   {% if ansible_os_family == "RedHat" %}
-Listen 443 https
+Listen {{ apache.ssl.port }} https
   {% endif %}
 
   {% if ansible_os_family == "RedHat" %}

--- a/templates/http.proxy.conf.j2
+++ b/templates/http.proxy.conf.j2
@@ -68,6 +68,7 @@ Listen 443 https
   {% endif %}
 {% endif %}
 
+{% if prometheus.install == true %}
   <Location "/prometheus">
     ProxyPass "http://localhost:9090/prometheus"
     ProxyPassReverse "http://localhost:9090/prometheus"
@@ -77,6 +78,7 @@ Listen 443 https
     ProxyPass "http://localhost:3000"
     ProxyPassReverse "http://localhost:3000"
   </Location>
+{% endif %}
 
   # custom error document when Glassfish isn't responding
   ErrorDocument 503 /503.html

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -2,6 +2,7 @@
 # dataverse/tests/group_vars/jenkins.yml
 
 apache:
+  enabled: true
   ssl:
     enabled: false
     remote_cert: false

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -7,6 +7,7 @@ dataverse_repo: https://github.com/IQSS/dataverse.git
 any_errors_fatal: false
 
 apache:
+  enabled: true
   ssl:
     enabled: false
     remote_cert: false

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -7,6 +7,7 @@ dataverse_repo: https://github.com/IQSS/dataverse.git
 any_errors_fatal: true
 
 apache:
+  enabled: true
   ssl:
     enabled: false
     remote_cert: false


### PR DESCRIPTION
* Introduces the option to enable or disable the apache configuration part of the role:  
   ```yaml
  apache:
  enabled: true
  ssl:
    enabled: false
    remote_cert: false
  # ... etc
   ```
* Replaces hard-coded 443 port for SSL in Apache config file with the `apache.ssl.port` (already existing).
* Only include Prometheus and Grafana if Prometheus is enabled.