### PR TITLE
Fix API blocking

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,7 @@ dataverse:
   allow_signups: true
   api:
     allow_lookup: false
-    blocked_endpoints: "admin,builtin-users"
+    blocked_endpoints: "admin,builtin-users,test"
     blocked_policy: "localhost-only"
     location: "http://localhost:8080/api"
     test_suite: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ apache:
     admin: true
     destroy: true
     sword: false
-    builtinUsers: true
+    builtin_users: true
 
 letsencrypt:
   enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,7 @@ apache:
     admin: true
     destroy: true
     sword: false
+    builtinUsers: true
 
 letsencrypt:
   enabled: false
@@ -43,7 +44,7 @@ dataverse:
   allow_signups: true
   api:
     allow_lookup: false
-    blocked_endpoints: "admin,test"
+    blocked_endpoints: "admin,builtin-users"
     blocked_policy: "localhost-only"
     location: "http://localhost:8080/api"
     test_suite: false

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -35,8 +35,8 @@
     - { prop: ":Shoulder", val: "{{ dataverse.doi.shoulder }}", desc: "DOI shoulder."}
     - { prop: ":ShibEnabled", val: "{{ shibboleth.enabled }}", desc: "enable/disable shibboleth" }
     - { prop: ":AllowSignUp", val: "{{ dataverse.allow_signups }}", desc: "don't allow self-signup"}
-    - { prop: ":BlockedApiEndpoints", val: "admin,test", desc: "APIs that are controlled"}
-    - { prop: ":BlockedApiPolicy", val: "localhost-only", desc: "control API access"}
+    - { prop: ":BlockedApiEndpoints", val: "{{ dataverse.api.blocked_endpoints }}", desc: "APIs that are controlled"}
+    - { prop: ":BlockedApiPolicy", val: "{{ dataverse.api.blocked_policy }}", desc: "control API access"}
     - { prop: ":FileFixityChecksumAlgorithm", val: "{{ dataverse.file_fixity_checksum_algorithm }}", desc: "checksum algorithm used for file fixity" }
 
 - include: dataverse-optional-settings.yml

--- a/templates/http.proxy.conf.j2
+++ b/templates/http.proxy.conf.j2
@@ -116,7 +116,7 @@ Listen 443 https
   RedirectMatch ^/dvn/api/data-deposit(.*) /
 {% endif %}
 
-{% if apache.block.builtinUsers == true %}
+{% if apache.block.builtin_users == true %}
   ProxyPassMatch ^/api/builtin-users !
   RedirectMatch ^/api/builtin-users(.*) /
 {% endif %}

--- a/templates/http.proxy.conf.j2
+++ b/templates/http.proxy.conf.j2
@@ -116,6 +116,11 @@ Listen 443 https
   RedirectMatch ^/dvn/api/data-deposit(.*) /
 {% endif %}
 
+{% if apache.block.builtinUsers == true %}
+  ProxyPassMatch ^/api/builtin-users !
+  RedirectMatch ^/api/builtin-users(.*) /
+{% endif %}
+
 {% if dataverse.previewers.on_same_server %}
   # allow previewers
   ProxyPassMatch ^/dataverse-previewers !


### PR DESCRIPTION
* Adds a variable `apache.block.builtin_users` to block calls to the builtin-users endpoint in the same way as the existing vars under `apache.block`.
* Fixes the default value for `dataverse.api.blocked_endpoints`.
* Makes sure `dataverse.api.blocked_endpoints` and `dataverse.api.blocked_policy` are actually used.