### PR TITLE
task to install multiple languages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,6 +77,7 @@ dataverse:
     language_packs:
       source: https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs.git
       version: develop
+    lang_directory: /opt/dv/lang
   copyright: "Your Institution"
   counter:
     enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -182,7 +182,7 @@ dataverse:
     root: /usr/local/solr
     user: solr
     version: 8.11.1
-    checksum: sha256:00b573afd3ae0a3dd4ff79668ee3c4193a1fc681aeb031da9a7385fbc01c1f1d
+    checksum: sha256:9ec540cbd8e45f3d15a6b615a22939f5e6242ca81099951a47d3c082c79866a9
     listen: 127.0.0.1
   srcdir: /tmp/dataverse
   thumbnails: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -181,7 +181,7 @@ dataverse:
     group: solr
     root: /usr/local/solr
     user: solr
-    version: 8.8.1
+    version: 8.11.1
     checksum: sha256:00b573afd3ae0a3dd4ff79668ee3c4193a1fc681aeb031da9a7385fbc01c1f1d
     listen: 127.0.0.1
   srcdir: /tmp/dataverse

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,16 @@ dataverse:
     otherSettings:
      - setting: FooterCopyright
        value: Your institute name here
+  language:
+    enabled: false # setting this to true allows the language task to run
+    languages:
+     - locale: en
+       title: English
+     - locale: de-DE
+       title: Deutsch
+    language_packs:
+      source: https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs.git
+      version: develop
   copyright: "Your Institution"
   counter:
     enabled: false

--- a/tasks/dataverse-languages.yml
+++ b/tasks/dataverse-languages.yml
@@ -11,13 +11,13 @@
 
 - name: create dataverse language file path if not set
   file:
-    path: /opt/dv/lang
+    path: "{{ dataverse.language.lang_directory }}"
     state: directory
     owner: '{{ dataverse.payara.user }}'
   when: (dataverse_lang_directory.stdout | trim) == ''
 
 - name: set dataverse language file path if not set
-  shell: "{{ payara_dir }}/bin/asadmin create-jvm-options -Ddataverse.lang.directory=/opt/dv/lang"
+  shell: "{{ payara_dir }}/bin/asadmin create-jvm-options -Ddataverse.lang.directory={{ dataverse.language.lang_directory }}"
   when: (dataverse_lang_directory.stdout | trim) == ''
 
 - name: clone dataverse language packs
@@ -31,7 +31,7 @@
 - name: copy default bundle to the language directory if it was just created
   copy:
     src: /tmp/dataverse_language_packs/en_US/Bundle.properties
-    dest: /opt/dv/lang
+    dest: "{{ dataverse.language.lang_directory }}"
     owner: '{{ dataverse.payara.user }}'
   when: (dataverse_lang_directory.stdout | trim) == ''
 
@@ -60,7 +60,7 @@
 
 - name: upload language pack
   uri:
-    url: http://localhost:8080/api/admin/datasetfield/loadpropertyfiles
+    url: {{ dataverse.api.location }}/admin/datasetfield/loadpropertyfiles
     method: POST
     headers:
       Content-type: "application/zip"
@@ -72,7 +72,7 @@
 
 - name: configure available languages
   uri:
-    url: http://localhost:8080/api/admin/settings/:Languages
+    url: {{ dataverse.api.location }}/admin/settings/:Languages
     method: PUT
     body: '{{ dataverse.language.languages }}'
     body_format: json
@@ -81,7 +81,7 @@
 
 - name: configure available languages
   uri:
-    url: http://localhost:8080/api/admin/settings/:MetadataLanguages
+    url: {{ dataverse.api.location }}/admin/settings/:MetadataLanguages
     method: PUT
     body: '{{ dataverse.language.languages }}'
     body_format: json

--- a/tasks/dataverse-languages.yml
+++ b/tasks/dataverse-languages.yml
@@ -1,0 +1,83 @@
+---
+
+- name: install and configure dataverse languages
+  debug:
+    msg: '##### DATAVERSE LANGUAGES #####'
+
+- name: get dataverse language file path
+  shell: "{{ payara_dir }}/bin/asadmin list-jvm-options | grep dataverse.lang.directory | sed 's/.*=//'"
+  register: dataverse_lang_directory
+  changed_when: false
+
+- name: create dataverse language file path if not set
+  file:
+    path: /opt/dv/lang
+    state: directory
+    owner: '{{ dataverse.payara.user }}'
+  when: (dataverse_lang_directory.stdout | trim) == ''
+
+- name: set dataverse language file path if not set
+  shell: "{{ payara_dir }}/bin/asadmin create-jvm-options -Ddataverse.lang.directory=/opt/dv/lang"
+  when: (dataverse_lang_directory.stdout | trim) == ''
+
+- name: restart payara after setting language directory
+  service: name=payara state=restarted
+  when: (dataverse_lang_directory.stdout | trim) == ''
+
+- name: clone dataverse language packs
+  local_action:
+    module: git
+    repo: "{{ dataverse.language.language_packs.source }}"
+    dest: "/tmp/dataverse_language_packs"
+    version: "{{ dataverse.language.language_packs.version }}"
+  run_once: true
+
+- name: prepare language file temporary directory
+  local_action: shell cd /tmp/dataverse_language_packs ; rm -rf tmp.bak ; [ -d tmp ] && mv tmp tmp.bak && rm tmp.bak/*.zip ; mkdir tmp
+  changed_when: false
+
+- name: copy language files to temporary directory
+  local_action: shell cd /tmp/dataverse_language_packs ; cp -R {{ item.locale }}*/*.properties tmp/
+  changed_when: false
+  with_items: "{{ dataverse.language.languages }}"
+
+- name: check if there was a change in the temporary directory
+  local_action: shell cd /tmp/dataverse_language_packs ; diff -r tmp tmp.bak
+  register: diff
+  changed_when: diff.rc != 0
+  failed_when: diff.rc > 2
+
+- name: create language pack
+  local_action: shell cd /tmp/dataverse_language_packs/tmp ; zip languages.zip *.properties
+  when: diff.changed
+
+- name: upload language pack
+  uri:
+    url: http://localhost:8080/api/admin/datasetfield/loadpropertyfiles
+    method: POST
+    headers:
+      Content-type: "application/zip"
+      Accept: application/json
+    src: /tmp/dataverse_language_packs/tmp/languages.zip
+    status_code: 200
+    body_format: raw
+  when: diff.changed
+
+- name: configure available languages
+  uri:
+    url: http://localhost:8080/api/admin/settings/:Languages
+    method: PUT
+    body: '{{ dataverse.language.languages }}'
+    body_format: json
+    status_code: 200
+  when: diff.changed
+
+- name: configure available languages
+  uri:
+    url: http://localhost:8080/api/admin/settings/:MetadataLanguages
+    method: PUT
+    body: '{{ dataverse.language.languages }}'
+    body_format: json
+    status_code: 200
+  when: diff.changed
+

--- a/tasks/dataverse-languages.yml
+++ b/tasks/dataverse-languages.yml
@@ -20,10 +20,6 @@
   shell: "{{ payara_dir }}/bin/asadmin create-jvm-options -Ddataverse.lang.directory=/opt/dv/lang"
   when: (dataverse_lang_directory.stdout | trim) == ''
 
-- name: restart payara after setting language directory
-  service: name=payara state=restarted
-  when: (dataverse_lang_directory.stdout | trim) == ''
-
 - name: clone dataverse language packs
   local_action:
     module: git
@@ -31,6 +27,17 @@
     dest: "/tmp/dataverse_language_packs"
     version: "{{ dataverse.language.language_packs.version }}"
   run_once: true
+
+- name: copy default bundle to the language directory if it was just created
+  copy:
+    src: /tmp/dataverse_language_packs/en_US/Bundle.properties
+    dest: /opt/dv/lang
+    owner: '{{ dataverse.payara.user }}'
+  when: (dataverse_lang_directory.stdout | trim) == ''
+
+- name: restart payara after setting language directory
+  service: name=payara state=restarted
+  when: (dataverse_lang_directory.stdout | trim) == ''
 
 - name: prepare language file temporary directory
   local_action: shell cd /tmp/dataverse_language_packs ; rm -rf tmp.bak ; [ -d tmp ] && mv tmp tmp.bak && rm tmp.bak/*.zip ; mkdir tmp

--- a/tasks/dataverse-languages.yml
+++ b/tasks/dataverse-languages.yml
@@ -60,7 +60,7 @@
 
 - name: upload language pack
   uri:
-    url: {{ dataverse.api.location }}/admin/datasetfield/loadpropertyfiles
+    url: "{{ dataverse.api.location }}/admin/datasetfield/loadpropertyfiles"
     method: POST
     headers:
       Content-type: "application/zip"
@@ -72,7 +72,7 @@
 
 - name: configure available languages
   uri:
-    url: {{ dataverse.api.location }}/admin/settings/:Languages
+    url: "{{ dataverse.api.location }}/admin/settings/:Languages"
     method: PUT
     body: '{{ dataverse.language.languages }}'
     body_format: json
@@ -81,7 +81,7 @@
 
 - name: configure available languages
   uri:
-    url: {{ dataverse.api.location }}/admin/settings/:MetadataLanguages
+    url: "{{ dataverse.api.location }}/admin/settings/:MetadataLanguages"
     method: PUT
     body: '{{ dataverse.language.languages }}'
     body_format: json

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,12 +15,7 @@
 
 - include: dataverse-required-variables.yml
   tags:
-   - payara
-   - dataverse
-   - storage
-   - postinstall
-   - s3
-   - gui
+   - always
 
 - include: rserve.yml
   when: rserve.install == true
@@ -127,6 +122,11 @@
   when: dataverse.previewers.enabled == true
   tags:
   - previewers
+
+- include: dataverse-languages.yml
+  when: dataverse.language.enabled == true
+  tags:
+  - languages
 
 - include: dataverse-externaltools.yml
   tags:

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -131,6 +131,17 @@ dataverse:
     home: /tmp/jacoco
     version: 0.8.6
   file_fixity_checksum_algorithm: "MD5"
+  language:
+    enabled: true
+    languages:
+     - locale: en
+       title: English
+     - locale: de-DE
+       title: Deutsch
+    language_packs:
+      source: https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs.git
+      version: develop
+    lang_directory: /opt/dv/lang
   memheap: 4096
   options:
     filepids: 
@@ -161,7 +172,7 @@ dataverse:
     group: solr
     root: /usr/local/solr
     user: solr
-    version: 8.8.1
+    version: 8.11.1
     listen: 127.0.0.1
     checksum: sha256:00b573afd3ae0a3dd4ff79668ee3c4193a1fc681aeb031da9a7385fbc01c1f1d
   srcdir: /tmp/dataverse
@@ -282,6 +293,6 @@ sshkeys:
 
 # un-nesting the below so's we can pass them at the CLI
 
-dataverse_branch: 52_tika_1_dot_28
-dataverse_repo: https://github.com/OdumInstitute/dataverse.git
+dataverse_branch: develop
+dataverse_repo: https://github.com/IQSS/dataverse.git
 any_errors_fatal: true

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -174,7 +174,7 @@ dataverse:
     user: solr
     version: 8.11.1
     listen: 127.0.0.1
-    checksum: sha256:00b573afd3ae0a3dd4ff79668ee3c4193a1fc681aeb031da9a7385fbc01c1f1d
+    checksum: sha256:9ec540cbd8e45f3d15a6b615a22939f5e6242ca81099951a47d3c082c79866a9
   srcdir: /tmp/dataverse
   thumbnails: false
   unittests:

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -176,7 +176,7 @@ dataverse:
     root: /usr/local/solr
     user: solr
     version: 8.11.1
-    checksum: sha256:00b573afd3ae0a3dd4ff79668ee3c4193a1fc681aeb031da9a7385fbc01c1f1d
+    checksum: sha256:9ec540cbd8e45f3d15a6b615a22939f5e6242ca81099951a47d3c082c79866a9
     listen: 127.0.0.1
   srcdir: /tmp/dataverse
   thumbnails: false

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -134,6 +134,17 @@ dataverse:
     home: /tmp/jacoco
     version: 0.8.6
   file_fixity_checksum_algorithm: "MD5"
+  language:
+    enabled: false # setting this to true allows the language task to run
+    languages:
+     - locale: en
+       title: English
+     - locale: de-DE
+       title: Deutsch
+    language_packs:
+      source: https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs.git
+      version: develop
+    lang_directory: /opt/dv/lang
   memheap: 2048
   options:
     filepids: 
@@ -164,7 +175,7 @@ dataverse:
     group: solr
     root: /usr/local/solr
     user: solr
-    version: 8.8.1
+    version: 8.11.1
     checksum: sha256:00b573afd3ae0a3dd4ff79668ee3c4193a1fc681aeb031da9a7385fbc01c1f1d
     listen: 127.0.0.1
   srcdir: /tmp/dataverse

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -179,7 +179,7 @@ dataverse:
     user: solr
     version: 8.11.1
     listen: 127.0.0.1
-    checksum: sha256:00b573afd3ae0a3dd4ff79668ee3c4193a1fc681aeb031da9a7385fbc01c1f1d
+    checksum: sha256:9ec540cbd8e45f3d15a6b615a22939f5e6242ca81099951a47d3c082c79866a9
   srcdir: /tmp/dataverse
   thumbnails: false
   unittests:

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -2,7 +2,7 @@
 # dataverse/tests/group_vars/vagrant.yml
 
 # un-nested so we can pass them at the CLI
-dataverse_branch: release
+dataverse_branch: develop
 dataverse_repo: https://github.com/IQSS/dataverse.git
 any_errors_fatal: true
 
@@ -106,6 +106,7 @@ dataverse:
       enabled: true
     wholetale:
       enabled: true
+  file_fixity_checksum_algorithm: "MD5"
   ## The first item of 'filesdirs' is the default filestore
   ## If you change the label, be prepared to change the SQL database if there are already files here
   ## It is better practice to add a new data store and then migrate to it later
@@ -135,7 +136,17 @@ dataverse:
     enabled: false
     home: /tmp/jacoco
     version: 0.8.6
-  file_fixity_checksum_algorithm: "MD5"
+  language:
+    enabled: true
+    languages:
+     - locale: en
+       title: English
+     - locale: de-DE
+       title: Deutsch
+    language_packs:
+      source: https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs.git
+      version: develop
+    lang_directory: /opt/dv/lang
   memheap: 1024
   options:
     filepids: 
@@ -166,7 +177,7 @@ dataverse:
     group: solr
     root: /usr/local/solr
     user: solr
-    version: 8.8.1
+    version: 8.11.1
     listen: 127.0.0.1
     checksum: sha256:00b573afd3ae0a3dd4ff79668ee3c4193a1fc681aeb031da9a7385fbc01c1f1d
   srcdir: /tmp/dataverse


### PR DESCRIPTION
I created a task to install multiple languages. It sets the language diretory path, downloads the [dataverse-language-packs](https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs) from git (configurable repo and branch), and zips the property files for the selected languages, uploads it and configures the selected languages in the given dataverse installation.

The configuration is done by the _dataverse.language_ property (example and default provided in defaults/main.yml), which contains a _dataverse.language.enabled_ property, which is false by default, thus disabling this function for not-interested users.

The contained tasks are _mostly_ idempotent, and try to skip admin interface calls if there are no changes compared to the previous runs.