### PR TITLE
Switch for postgres

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -185,6 +185,7 @@ build_guides: false
 
 db:
   postgres:
+    enabled: true
     adminpass: DVn33dsth1s
     name: dvndb
     host: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,7 @@
   - apache
 
 - include: postgres.yml
+  when: postgres.db.enabled == True
   tags:
   - postgres
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,7 +48,7 @@
   - apache
 
 - include: postgres.yml
-  when: postgres.db.enabled == True
+  when: db.postgres.enabled == True
   tags:
   - postgres
 

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -176,6 +176,7 @@ build_guides: false
 
 db:
   postgres:
+    enabled: true
     adminpass: DVn33dsth1s
     name: dvndb
     host: localhost

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -179,6 +179,7 @@ build_guides: false
 
 db:
   postgres:
+    enabled: true
     adminpass: DVn33dsth1s
     name: dvndb
     host: localhost

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -181,6 +181,7 @@ build_guides: false
 
 db:
   postgres:
+    enabled: true
     adminpass: DVn33dsth1s
     name: vagrantdb
     host: localhost


### PR DESCRIPTION
Adds an `enabled` boolean for switching on/off the PostGreSQL configuration part of the role, similar to existing switches for Apache, Shibboleth, etc.