### PR TITLE
Test whether JMSAppender.class exists before deleting

### DIFF
--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -66,7 +66,7 @@
 
 - name: remove JMSAppender from bundled log4j
   ansible.builtin.shell:
-    cmd: 'zip -q -d {{ item }} org/apache/log4j/net/JMSAppender.class'
+    cmd: 'unzip -t {{ item }} org/apache/log4j/net/JMSAppender.class ; [ $? -eq 11 ] && true || zip -q -d {{ item }} org/apache/log4j/net/JMSAppender.class'
   become: yes
   become_user: '{{ dataverse.payara.user }}'
   with_items:


### PR DESCRIPTION
Test whether JMSAppender.class exists in the log4j jars before trying to delete them.
Unzip gives error code 11 if the specified file is not found, so we just return success in that case.
This should make the "remove JMSAppender from bundled log4j" step idempotent.