### PR TITLE
handle configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,17 +103,18 @@ dataverse:
     config:
     storage_id: file
   demo: false
-  doi:
+  pid:
     authority: "10.5072"
+    protocol: doi
+    shoulder: "FK2/"
+  doi:
     baseurl: "https://mds.test.datacite.org/"
     dataciterestapiurl: "https://api.test.datacite.org"
     mdcbaseurl: "https://api.test.datacite.org/"
+    provider: FAKE
     username: "testaccount"
     password: "notmypassword"
-    protocol: doi
-    provider: FAKE
-    shoulder: "FK2/"
-  ## Handlenet variables are only used if dataverse.doi.protocol is set to 'hdl'
+  ## Handlenet variables are only used if dataverse.pid.protocol is set to 'hdl'
   handlenet:
     independenthandleservice: 'false'
 #   handleauthhandle: YOUR:HANDLE/USERNAME

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -105,8 +105,8 @@ dataverse:
   ## Handlenet variables are only used if dataverse.doi.protocol is set to 'hdl'
   handlenet:
     independenthandleservice: 'false'
-#   handleauthhandle:
-#   admcredfile: /opt/dv/admpriv.bin
+#   handleauthhandle: YOUR:HANDLE/USERNAME
+    admcredfile: /opt/dv/admpriv.bin
     admcredfile_source: files/handlenet/admcredfile
 #   admprivphrase:
 #   index: 300

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,6 +102,13 @@ dataverse:
     protocol: doi
     provider: FAKE
     shoulder: "FK2/"
+  ## Handlenet variables are only used if dataverse.doi.protocol is set to 'hdl'
+  handlenet:
+    independenthandleservice: 'false'
+#   handleauthhandle:
+    admcredfile: /opt/dv/admpriv.bin
+#   admprivphrase:
+#   index: 300
   externaltools:
     datacurationtool:
       enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -107,6 +107,7 @@ dataverse:
     independenthandleservice: 'false'
 #   handleauthhandle:
     admcredfile: /opt/dv/admpriv.bin
+    admcredfile_source: files/handlenet/admcredfile
 #   admprivphrase:
 #   index: 300
   externaltools:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -106,7 +106,7 @@ dataverse:
   handlenet:
     independenthandleservice: 'false'
 #   handleauthhandle:
-    admcredfile: /opt/dv/admpriv.bin
+#   admcredfile: /opt/dv/admpriv.bin
     admcredfile_source: files/handlenet/admcredfile
 #   admprivphrase:
 #   index: 300

--- a/tasks/dataverse-handlenet.yml
+++ b/tasks/dataverse-handlenet.yml
@@ -1,0 +1,55 @@
+
+- name: set IndependentHandleService
+  uri:
+    url: "{{ dataverse.api.location }}/admin/settings/:IndependentHandleService"
+    method: PUT
+    body: "{{ dataverse.handlenet.independenthandleservice }}"
+    body_format: raw
+
+- name: set HandleAuthHandle
+  uri:
+    url: "{{ dataverse.api.location }}/admin/settings/:HandleAuthHandle"
+    method: PUT
+    body: "{{ dataverse.handlenet.handleauthhandle }}"
+    body_format: raw
+  when:
+   - dataverse.handlenet.handleauthhandle is defined
+
+- name: copy dataverse.handlenet.admcredfile
+  copy:
+    src: files/handlenet/admcredfile
+    dest: "{{ dataverse.handlenet.admcredfile }}"
+
+- name: get dataverse.handlenet.admcredfile value
+  shell: "{{ payara_dir }}/bin/asadmin list-jvm-options | grep dataverse.handlenet.admcredfile="
+  register: admcredfile_value
+  failed_when: false
+
+- name: set dataverse.handlenet.admcredfile if changed
+  shell: "{{ payara_dir }}/bin/asadmin delete-jvm-options '{{ admcredfile_value.stdout | trim }}' ;
+          {{ payara_dir }}/bin/asadmin create-jvm-options '-Ddataverse.handlenet.admcredfile={{ dataverse.handlenet.admcredfile }}'"
+  when: ( admcredfile_value.stdout | trim ) != '-Ddataverse.handlenet.admcredfile='+dataverse.handlenet.admcredfile
+
+- name: get dataverse.handlenet.admprivphrase value
+  shell: "{{ payara_dir }}/bin/asadmin list-jvm-options | grep dataverse.handlenet.admprivphrase="
+  register: admprivphrase_value
+  failed_when: false
+
+- name: set dataverse.handlenet.admprivphrase if set and changed
+  shell: "{{ payara_dir }}/bin/asadmin delete-jvm-options '{{ admprivphrase_value.stdout | trim }}' ;
+          {{ payara_dir }}/bin/asadmin create-jvm-options '-Ddataverse.handlenet.admprivphrase={{ dataverse.handlenet.admprivphrase }}'"
+  when:
+   - dataverse.handlenet.admprivphrase is defined
+   - ( admprivphrase_value.stdout | trim ) != '-Ddataverse.handlenet.admprivphrase='+dataverse.handlenet.admprivphrase
+
+- name: get dataverse.handlenet.index value
+  shell: "{{ payara_dir }}/bin/asadmin list-jvm-options | grep dataverse.handlenet.index="
+  register: index_value
+  failed_when: false
+
+- name: set dataverse.handlenet.index if set and changed
+  shell: "{{ payara_dir }}/bin/asadmin create-jvm-options '{{ index_value.stdout | trim }}' ;
+          {{ payara_dir }}/bin/asadmin create-jvm-options '-Ddataverse.handlenet.index={{ dataverse.handlenet.index }}'"
+  when:
+   - dataverse.handlenet.index is defined
+   - ( index_value.stdout | trim ) != '-Ddataverse.handlenet.index='+dataverse.handlenet.index

--- a/tasks/dataverse-handlenet.yml
+++ b/tasks/dataverse-handlenet.yml
@@ -17,7 +17,7 @@
 
 - name: copy dataverse.handlenet.admcredfile
   copy:
-    src: files/handlenet/admcredfile
+    src: "{{ dataverse.handlenet.admcredfile_source }}"
     dest: "{{ dataverse.handlenet.admcredfile }}"
 
 - name: get dataverse.handlenet.admcredfile value

--- a/tasks/dataverse-handlenet.yml
+++ b/tasks/dataverse-handlenet.yml
@@ -19,16 +19,23 @@
   copy:
     src: "{{ dataverse.handlenet.admcredfile_source }}"
     dest: "{{ dataverse.handlenet.admcredfile }}"
+  when:
+   - dataverse.handlenet.admcredfile is defined
 
 - name: get dataverse.handlenet.admcredfile value
   shell: "{{ payara_dir }}/bin/asadmin list-jvm-options | grep dataverse.handlenet.admcredfile="
   register: admcredfile_value
   failed_when: false
 
+- name: delete dataverse.handlenet.admcredfile if changed
+  shell: "{{ payara_dir }}/bin/asadmin delete-jvm-options '{{ admcredfile_value.stdout | trim }}'"
+  when: ( dataverse.handlenet.admcredfile is defined and ( admcredfile_value.stdout | trim ) != '-Ddataverse.handlenet.admcredfile='+dataverse.handlenet.admcredfile ) or ( dataverse.handlenet.admcredfile is not defined and ( admcredfile_value.stdout | trim ) != '' )
+
 - name: set dataverse.handlenet.admcredfile if changed
-  shell: "{{ payara_dir }}/bin/asadmin delete-jvm-options '{{ admcredfile_value.stdout | trim }}' ;
-          {{ payara_dir }}/bin/asadmin create-jvm-options '-Ddataverse.handlenet.admcredfile={{ dataverse.handlenet.admcredfile }}'"
-  when: ( admcredfile_value.stdout | trim ) != '-Ddataverse.handlenet.admcredfile='+dataverse.handlenet.admcredfile
+  shell: "{{ payara_dir }}/bin/asadmin create-jvm-options '-Ddataverse.handlenet.admcredfile={{ dataverse.handlenet.admcredfile }}'"
+  when:
+   - dataverse.handlenet.admcredfile is defined
+   - ( admcredfile_value.stdout | trim ) != '-Ddataverse.handlenet.admcredfile='+dataverse.handlenet.admcredfile
 
 - name: get dataverse.handlenet.admprivphrase value
   shell: "{{ payara_dir }}/bin/asadmin list-jvm-options | grep dataverse.handlenet.admprivphrase="

--- a/tasks/dataverse-handlenet.yml
+++ b/tasks/dataverse-handlenet.yml
@@ -15,6 +15,20 @@
   when:
    - dataverse.handlenet.handleauthhandle is defined
 
+- name: set Authority
+  uri:
+    url: "{{ dataverse.api.location }}/admin/settings/:Authority"
+    method: PUT
+    body: "{{ dataverse.doi.authority }}"
+    body_format: raw
+
+- name: set Shoulder
+  uri:
+    url: "{{ dataverse.api.location }}/admin/settings/:Shoulder"
+    method: PUT
+    body: "{{ dataverse.doi.shoulder }}"
+    body_format: raw
+
 - name: copy dataverse.handlenet.admcredfile
   copy:
     src: "{{ dataverse.handlenet.admcredfile_source }}"
@@ -26,6 +40,7 @@
   shell: "{{ payara_dir }}/bin/asadmin list-jvm-options | grep dataverse.handlenet.admcredfile="
   register: admcredfile_value
   failed_when: false
+  changed_when: false
 
 - name: delete dataverse.handlenet.admcredfile if changed
   shell: "{{ payara_dir }}/bin/asadmin delete-jvm-options '{{ admcredfile_value.stdout | trim }}'"
@@ -41,6 +56,7 @@
   shell: "{{ payara_dir }}/bin/asadmin list-jvm-options | grep dataverse.handlenet.admprivphrase="
   register: admprivphrase_value
   failed_when: false
+  changed_when: false
 
 - name: set dataverse.handlenet.admprivphrase if set and changed
   shell: "{{ payara_dir }}/bin/asadmin delete-jvm-options '{{ admprivphrase_value.stdout | trim }}' ;
@@ -53,6 +69,7 @@
   shell: "{{ payara_dir }}/bin/asadmin list-jvm-options | grep dataverse.handlenet.index="
   register: index_value
   failed_when: false
+  changed_when: false
 
 - name: set dataverse.handlenet.index if set and changed
   shell: "{{ payara_dir }}/bin/asadmin create-jvm-options '{{ index_value.stdout | trim }}' ;

--- a/tasks/dataverse-handlenet.yml
+++ b/tasks/dataverse-handlenet.yml
@@ -15,20 +15,6 @@
   when:
    - dataverse.handlenet.handleauthhandle is defined
 
-- name: set Authority
-  uri:
-    url: "{{ dataverse.api.location }}/admin/settings/:Authority"
-    method: PUT
-    body: "{{ dataverse.doi.authority }}"
-    body_format: raw
-
-- name: set Shoulder
-  uri:
-    url: "{{ dataverse.api.location }}/admin/settings/:Shoulder"
-    method: PUT
-    body: "{{ dataverse.doi.shoulder }}"
-    body_format: raw
-
 - name: copy dataverse.handlenet.admcredfile
   copy:
     src: "{{ dataverse.handlenet.admcredfile_source }}"

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -29,10 +29,10 @@
     - { prop: ":GoogleAnalyticsCode", val: "{{ dataverse.google_analytics_key }}", desc: "key for Google Analytics"}
     - { prop: ":FooterCopyright" , val: "{{ dataverse.copyright }}", desc: "addition to the default copyright statement"}
     - { prop: ":SystemEmail", val: "{{ dataverse.service_email }}", desc: "instance email address"}
-    - { prop: ":Protocol", val: "{{ dataverse.doi.protocol }}", desc: "global identifier protocol"}
+    - { prop: ":Protocol", val: "{{ dataverse.pid.protocol }}", desc: "global identifier protocol"}
     - { prop: ":DoiProvider", val: "{{ dataverse.doi.provider }}", desc: "DOI service provider (EZID or DataCite)"}
-    - { prop: ":Authority", val: "{{ dataverse.doi.authority }}", desc: "DOI prefix"}
-    - { prop: ":Shoulder", val: "{{ dataverse.doi.shoulder }}", desc: "DOI shoulder."}
+    - { prop: ":Authority", val: "{{ dataverse.pid.authority }}", desc: "DOI/handle prefix"}
+    - { prop: ":Shoulder", val: "{{ dataverse.pid.shoulder }}", desc: "DOI/handle shoulder."}
     - { prop: ":ShibEnabled", val: "{{ shibboleth.enabled }}", desc: "enable/disable shibboleth" }
     - { prop: ":AllowSignUp", val: "{{ dataverse.allow_signups }}", desc: "don't allow self-signup"}
     - { prop: ":BlockedApiEndpoints", val: "{{ dataverse.api.blocked_endpoints }}", desc: "APIs that are controlled"}
@@ -42,7 +42,7 @@
 - include: dataverse-optional-settings.yml
 
 - include: dataverse-handlenet.yml
-  when: dataverse.doi.protocol == 'hdl'
+  when: dataverse.pid.protocol == 'hdl'
 
 - name: final payara post-configuration cleanup
   service:

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -41,6 +41,9 @@
 
 - include: dataverse-optional-settings.yml
 
+- include: dataverse-handlenet.yml
+  when: dataverse.doi.protocol == 'hdl'
+
 - name: final payara post-configuration cleanup
   service:
     name: payara
@@ -63,6 +66,9 @@
     recurse: yes
     use_regex: yes
   register: log4jv1_list
+  tags: log4j-v1
+
+#- fail: msg='{{ log4jv1_list.files }}'
 
 - name: remove JMSAppender from bundled log4j
   ansible.builtin.shell:
@@ -71,6 +77,8 @@
   become_user: '{{ dataverse.payara.user }}'
   with_items:
   - "{{ log4jv1_list.files | map(attribute='path') | list }}"
+  tags: log4j-v1
+  
 
 - name: start payara
   service:

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -83,6 +83,10 @@ dataverse:
     config:
     storage_id: file
   demo: false
+  pid:
+    authority: "10.5072"
+    protocol: doi
+    shoulder: "FK2/"
   doi:
     authority: "10.5072"
     baseurl: "https://mds.test.datacite.org/"

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -83,17 +83,18 @@ dataverse:
     config:
     storage_id: file
   demo: false
-  doi:
+  pid:
     authority: "10.5072"
+    protocol: doi
+    shoulder: "FK2/"
+  doi:
     baseurl: "https://mds.test.datacite.org/"
     username: "test.account"
     password: "not.my.password"
-    protocol: doi
-    provider: FAKE
     shoulder: "FK2/"
     mdcbaseurl: "https://api.test.datacite.org/"
     dataciterestapiurl: "https://api.test.datacite.org"
-  ## Handlenet variables are only used if dataverse.doi.protocol is set to 'hdl'
+  ## Handlenet variables are only used if dataverse.pid.protocol is set to 'hdl'
   handlenet:
     independenthandleservice: 'false'
 #   handleauthhandle: YOUR:HANDLE/USERNAME

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -93,6 +93,14 @@ dataverse:
     shoulder: "FK2/"
     mdcbaseurl: "https://api.test.datacite.org/"
     dataciterestapiurl: "https://api.test.datacite.org"
+  ## Handlenet variables are only used if dataverse.doi.protocol is set to 'hdl'
+  handlenet:
+    independenthandleservice: 'false'
+#   handleauthhandle: YOUR:HANDLE/USERNAME
+    admcredfile: /opt/dv/admpriv.bin
+    admcredfile_source: files/handlenet/admcredfile
+#   admprivphrase:
+#   index: 300
   externaltools:
     datacurationtool:
       enabled: true

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -96,6 +96,14 @@ dataverse:
     protocol: doi
     provider: FAKE
     shoulder: "FK2/"
+  ## Handlenet variables are only used if dataverse.doi.protocol is set to 'hdl'
+  handlenet:
+    independenthandleservice: 'false'
+#   handleauthhandle: YOUR:HANDLE/USERNAME
+    admcredfile: /opt/dv/admpriv.bin
+    admcredfile_source: files/handlenet/admcredfile
+#   admprivphrase:
+#   index: 300
   externaltools:
     datacurationtool:
       enabled: true

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -87,6 +87,10 @@ dataverse:
   default:
     config:
   demo: false
+  pid:
+    authority: "10.5072"
+    protocol: doi
+    shoulder: "FK2/"
   doi:
     authority: "10.5072"
     baseurl: "https://mds.test.datacite.org/"

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -87,16 +87,17 @@ dataverse:
   default:
     config:
   demo: false
-  doi:
+  pid:
     authority: "10.5072"
+    protocol: doi
+    shoulder: "FK2/"
+  doi:
     baseurl: "https://mds.test.datacite.org/"
     mdcbaseurl: "https://api.test.datacite.org/"
     username: "testaccount"
     password: "notmypassword"
-    protocol: doi
     provider: FAKE
-    shoulder: "FK2/"
-  ## Handlenet variables are only used if dataverse.doi.protocol is set to 'hdl'
+  ## Handlenet variables are only used if dataverse.pid.protocol is set to 'hdl'
   handlenet:
     independenthandleservice: 'false'
 #   handleauthhandle: YOUR:HANDLE/USERNAME

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -88,16 +88,17 @@ dataverse:
     config:
     storage_id: file
   demo: false
-  doi:
+  pid:
     authority: "10.5072"
+    protocol: doi
+    shoulder: "FK2/"
+  doi:
     baseurl: "https://mds.test.datacite.org/"
     dataciterestapiurl: "https://api.test.datacite.org"
     mdcbaseurl: "https://api.test.datacite.org/"
     username: "test.account"
     password: "not.my.password"
-    protocol: doi
     provider: FAKE
-    shoulder: "FK2/"
   externaltools:
     datacurationtool:
       enabled: true

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -88,17 +88,18 @@ dataverse:
     config:
     storage_id: file
   demo: false
-  doi:
+  pid:
     authority: "10.5072"
+    protocol: doi
+    shoulder: "FK2/"
+  doi:
     baseurl: "https://mds.test.datacite.org/"
     dataciterestapiurl: "https://api.test.datacite.org"
     mdcbaseurl: "https://api.test.datacite.org/"
     username: "test.account"
     password: "not.my.password"
-    protocol: doi
     provider: FAKE
-    shoulder: "FK2/"
-  ## Handlenet variables are only used if dataverse.doi.protocol is set to 'hdl'
+  ## Handlenet variables are only used if dataverse.pid.protocol is set to 'hdl'
   handlenet:
     independenthandleservice: 'false'
 #   handleauthhandle: YOUR:HANDLE/USERNAME

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -98,6 +98,14 @@ dataverse:
     protocol: doi
     provider: FAKE
     shoulder: "FK2/"
+  ## Handlenet variables are only used if dataverse.doi.protocol is set to 'hdl'
+  handlenet:
+    independenthandleservice: 'false'
+#   handleauthhandle: YOUR:HANDLE/USERNAME
+    admcredfile: /opt/dv/admpriv.bin
+    admcredfile_source: files/handlenet/admcredfile
+#   admprivphrase:
+#   index: 300
   externaltools:
     datacurationtool:
       enabled: true


### PR DESCRIPTION
Currently, you can not fully initialize handle usage using dataverse-ansible. This patch fixes that, by adding a `dataverse-handlenet.yml` into `dataverse-postinstall.yml` that only executes if protocol is set to hdl.

Typically, the default settings are fine. For using handles, you only need to set:
- `dataverse.doi.protocol: hdl`
- `dataverse.doi.authority` to your authority
- `dataverse.doi.shoulder` to your suffix value
- `dataverse.handlenet.handleauthhandle` to your handle username suffix (typically 21.XYYYYY/SHOULDER)
AND also copy your handle.net private key to its place (`files/handlenet/admcredfile` by default).

If you want to tweak the handle-related configuration variables, there is a new `dataverse.handlenet` variable that contains the following:

- `independenthandleservice`: corresponds to `:IndependentHandleService`
- `admcredfile`: corresponds to `dataverse.handlenet.admcredfile` JVM setting, it only defines where the file should be stored on the dataverse server.
- `admcredfile_source`: The `admcredfile` is uploaded from this path on the ansible controller.
- `admprivphrase`: corresponds to `dataverse.handlenet.admprivphrase` JVM setting, sets the password for the private key
- `index`: corresponds to `dataverse.handlenet.index` JVM setting, this is a prefix for the handle.net username

