### PR TITLE
debian10 psycopg2 install

### DIFF
--- a/tasks/postgres.yml
+++ b/tasks/postgres.yml
@@ -9,8 +9,10 @@
   package:
     name: python-psycopg2
     state: latest
-  when: ansible_os_family == "RedHat" and
-        ansible_distribution_major_version == "7"
+  when: (ansible_os_family == "RedHat" and
+        ansible_distribution_major_version == "7") or
+        (ansible_os_family == "Debian" and
+        ansible_distribution_major_version == "10")
 
 - name: ansible postgres module wants python3-psycopg2
   package:


### PR DESCRIPTION
psycopg2 was not installed on debian 10 due to error in the conditionals