### PR TITLE
fix rename of previewers folder if folder already exists

### DIFF
--- a/tasks/dataverse-previewers.yml
+++ b/tasks/dataverse-previewers.yml
@@ -20,7 +20,7 @@
   when: dataverse.previewers.on_same_server == true
 
 - name: rename dataverse previewers folder
-  shell: 'mv {{ dataverse.previewers.dir }}/dataverse-previewers-* {{ dataverse.previewers.dir }}/dataverse-previewers'
+  shell: '[ -d {{ dataverse.previewers.dir }}/dataverse-previewers/dataverse-previewers-* ] || mv {{ dataverse.previewers.dir }}/dataverse-previewers-* {{ dataverse.previewers.dir }}/dataverse-previewers'
   when: dataverse.previewers.on_same_server == true
 
 - name: 1.2 release zip includes 1.1.1


### PR DESCRIPTION
Because otherwise, the task sometimes fails on existing installations.