### PR TITLE
fix wrong condition order in dataverse-fqdn

### DIFF
--- a/tasks/dataverse-fqdn.yml
+++ b/tasks/dataverse-fqdn.yml
@@ -69,15 +69,15 @@
   ansible.builtin.set_fact:
     public_hostname: "{{ ec2_hostname_output.content }}"
   when: is_aws_environment
-        and is_public_hostname
         and custom_fqdn is undefined
+        and is_public_hostname
 
 - name: correct siteUrl for EC2
   ansible.builtin.set_fact:
     siteUrl: '{{ protocol }}://{{ public_hostname }}'
   when: is_aws_environment
-        and is_public_hostname
         and custom_fqdn is undefined
+        and is_public_hostname
 
 # for asadmin command
 - name: escape colons in siteurl

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,7 @@
   tags:
    - prereqs
    - apache
+   - fqdn
 
 - include: sshkeys.yml
   when: sshkeys.enabled == True


### PR DESCRIPTION
- fix wrong condition order in dataverse-fqdn that only occurs if apache.public_fqdn is defined when EC2 is detected
  - is_public_hostname is not defined in this case
- add fqdn tag for dataverse-fqdn testing