### PR TITLE
Apache proxy task order

### DIFF
--- a/tasks/dataverse-apache.yml
+++ b/tasks/dataverse-apache.yml
@@ -22,7 +22,7 @@
   when: ansible_os_family == "Debian"
 
 - name: install Apache for RedHat/Rocky
-  yum: 
+  yum:
     name: ['httpd', 'mod_ssl']
     state: latest
   when: ansible_os_family == "RedHat"
@@ -73,7 +73,7 @@
   template:
     src: ports.conf.j2
     dest: "{{ apache_config_base_dir }}/ports.conf"
-  when: ansible_os_family == "Debian" ## TODO where is this in RedHat? ## it would be nicer to use than the Listen statement at the start of the virtualhost
+  when: ansible_os_family == "Debian"  ## TODO where is this in RedHat? ## it would be nicer to use than the Listen statement at the start of the virtualhost
   notify: enable and restart apache
 
 - include: dataverse-apache-ssl.yml

--- a/tasks/dataverse-apache.yml
+++ b/tasks/dataverse-apache.yml
@@ -34,15 +34,6 @@
   when: ansible_os_family == "Debian"
   notify: enable and restart apache
 
-- name: install unified http proxy config
-  template:
-    src: http.proxy.conf.j2
-    dest: "{{ apache_virtualhost_dir }}/http.proxy.conf"
-    owner: root
-    group: root
-    mode: '0644'
-  notify: enable and restart apache
-
 - name: enable apache mods on Debian
   apache2_module:
     state: present
@@ -52,6 +43,15 @@
     - proxy_http
     - proxy_ajp
   when: ansible_os_family == "Debian"    ## CHECKME -- does this need to be Debian-specific?
+  notify: enable and restart apache
+
+- name: install unified http proxy config
+  template:
+    src: http.proxy.conf.j2
+    dest: "{{ apache_virtualhost_dir }}/http.proxy.conf"
+    owner: root
+    group: root
+    mode: '0644'
   notify: enable and restart apache
 
 - name: disable default Debian site


### PR DESCRIPTION
This PR reverts the changes made in https://github.com/GlobalDataverseCommunityConsortium/dataverse-ansible/commit/8af15b787ce105963ed90125f43635b389f697cf and closes #246 

The task `enable apache mods on Debian` enables modules using a2enable under the hood. This performs a configcheck under the hood. This configcheck can only succeed, if `proxy` and `proxy_http` are both enabled and thus prevents them from being enabled.

An alternative solution for this would be to skip the configcheck, using the `ignore_configcheck` parameter:
```yaml
- name: enable apache mods on Debian
  apache2_module:
    state: present
    name: "{{ item }}"
    ignore_configcheck: true
  with_items:
    - proxy
    - proxy_http
    - proxy_ajp
  when: ansible_os_family == "Debian"    ## CHECKME -- does this need to be Debian-specific?
  notify: enable and restart apache
```
This, however, could mask other errors.