### PR TITLE
Updated regex to replace hosting location of dataverse previewers.

### DIFF
--- a/tasks/dataverse-previewers.yml
+++ b/tasks/dataverse-previewers.yml
@@ -37,7 +37,7 @@
 - name: modify dataverse-previewers.sh script for local hosting previewers
   replace:
     path: '{{ ansible_user_dir }}/dataverse-previewers.sh'
-    regexp: 'https://globaldataversecommunityconsortium.github.io'
+    regexp: 'https://gdcc.github.io'
     replace: '{{ dataverse.payara.siteurl }}'
   when: dataverse.previewers.on_same_server == true
 


### PR DESCRIPTION
This PR updates the URL which replaces the URLs of dataverse previewers for local hosting (using `dataverse-previewers.sh`).

The new hosting location is present in the bash script, but the replacement regex fails, since `globaldataversecommunityconsortium` cannot be found in the updated script.

