### PR TITLE
Disable selinux on debian

### DIFF
--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -5,9 +5,9 @@
     state: latest
   vars:
     packages:
-    - setools
-    - setools-console
-    - policycoreutils
+      - setools
+      - setools-console
+      - policycoreutils
   when: ansible_os_family == 'RedHat'
 
 # Ansible seboolean module is broken on RHEL/Rocky 8.6. dls 20220602
@@ -21,8 +21,8 @@
 - name: allow apache to make outbound connections
   shell: '/usr/sbin/setsebool -P httpd_can_network_connect 1'
   when:
-  - ansible_os_family == "RedHat"
-  - ansible_distribution_major_version == "8"
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == "8"
 
 # Ansible seboolean module is broken on RHEL/Rocky 8.6. dls 20220602
 #- name: allow apache to read user content by default
@@ -36,8 +36,8 @@
 - name: allow apache to read user content by default
   shell: 'setsebool -P httpd_read_user_content 1'
   when:
-  - ansible_os_family == "RedHat"
-  - ansible_distribution_major_version == "8"
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version == "8"
 
 - name: "both redhat and ubuntu default to /var/www/html"
   shell: 'semanage fcontext -a -t httpd_sys_content_t "/var/www/html(/.*)?" || semanage fcontext -m -t httpd_sys_content_t "/var/www/html(/.*)?"'

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -41,6 +41,10 @@
 
 - name: "both redhat and ubuntu default to /var/www/html"
   shell: 'semanage fcontext -a -t httpd_sys_content_t "/var/www/html(/.*)?" || semanage fcontext -m -t httpd_sys_content_t "/var/www/html(/.*)?"'
+  when:
+    - ansible_os_family == "RedHat"
 
 - name: "allow apache read-only access to /var/www/html"
   shell: 'restorecon -R -v /var/www/html'
+  when:
+    - ansible_os_family == "RedHat"


### PR DESCRIPTION
This PR ads `when` conditions to the last two selinux tasks to prevent those from running on Debian. This is consistent with the remaining selinux tasks and will fail on a Debian machine that does not have selinux installed (since installation only runs on RedHat systems).

The white space changes are optional, but they make my YAML linter happy. I hope this is ok and I don't violate any code styles with this.