### PR TITLE
fix bracket placement within Rscript packages install

### DIFF
--- a/tasks/rserve.yml
+++ b/tasks/rserve.yml
@@ -82,7 +82,7 @@
 - name: install R modules
   command: >
     /usr/bin/Rscript --slave --no-save --no-restore-history -e
-    "install.packages('{{ item }}', repos=c('https://cloud.r-project.org/', Ncpus='{{ num_cores }}', quiet=TRUE));
+    "install.packages('{{ item }}', repos=c('https://cloud.r-project.org/'), Ncpus='{{ num_cores }}', quiet=TRUE);
     if(!library('{{ item }}', character.only=TRUE, logical.return=TRUE)){quit(status=1, save='no')};"
   with_items: "{{ modules_to_install }}"
   when: modules_to_install is defined


### PR DESCRIPTION
Does fix URL clobbering which forced the Rscript installer to fall back on the default. Additionally the arguments of the install.package function take effect.

Error was introduced in https://github.com/GlobalDataverseCommunityConsortium/dataverse-ansible/commit/29ef5baa4ed0cf03ee26c63170e8ae75b385e881