### PR TITLE
start solr indexing in postinst

### DIFF
--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -93,3 +93,8 @@
 - name: give Payara ample time to become ready
   ansible.builtin.pause:
     seconds: 90
+
+- name: start solr indexing -- if this was an upgrade to an existing install, the install scripts reset the solr indexes
+  ansible.builtin.get_url:
+    url: http://localhost:8080/api/admin/index
+    dest: /tmp/index_status.out


### PR DESCRIPTION
 - if this was an upgrade to an existing install, the install scripts reset the solr indexes, so this is needed
 - if this was a fresh install, it does not really matter