### PR TITLE
make solr download idempotent by specifying the downloaded file name

### DIFF
--- a/tasks/solr.yml
+++ b/tasks/solr.yml
@@ -28,7 +28,7 @@
   get_url:
     url: "https://archive.apache.org/dist/lucene/solr/{{ dataverse.solr.version }}/solr-{{ dataverse.solr.version }}.tgz"
     checksum: "{{ dataverse.solr.checksum }}"
-    dest: /tmp
+    dest: /tmp/solr-{{ dataverse.solr.version }}.tgz
   register: solr_installer_download
 
 - name: untar solr


### PR DESCRIPTION
 - no download is attempted if checksum matches
 - this is useful if the solr archive is temporarily inaccessible (as it was today)