### PR TITLE
Dataverse deploy upgrade only

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -257,6 +257,8 @@ dataverse:
     argument: '-DcompilerArgument=-Xlint:unchecked test -P all-unit-tests'
   usermgmtkey: burrito
   version: '5.13'
+  deployment:
+    upgrade_only: false
 
 build_guides: false
 

--- a/tasks/dataverse-install.yml
+++ b/tasks/dataverse-install.yml
@@ -143,12 +143,20 @@
   become_user: '{{ dataverse.payara.user }}'
   args:
     chdir: /tmp/dvinstall
+  when: not dataverse.deployment.upgrade_only
+
+- name: upgrade only -- deploy dataverse war
+  shell: '{{ payara_dir }}/bin/asadmin redeploy --name dataverse /tmp/dvinstall/dataverse.war'
+  become: yes
+  become_user: '{{ dataverse.payara.user }}'
+  when: dataverse.deployment.upgrade_only
 
 - name: stop payara manually (systemd gums up the works)
   become: yes
   become_user: "{{ dataverse.payara.user }}"
   shell: '{{ payara_dir }}/bin/asadmin stop-domain {{ dataverse.payara.domain }}'
   ignore_errors: yes
+  when: not dataverse.deployment.upgrade_only
 
 - name: now start payara with systemd
   service:

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -98,3 +98,4 @@
   ansible.builtin.get_url:
     url: http://localhost:8080/api/admin/index
     dest: /tmp/index_status.out
+  when: not upgrade_only

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -98,4 +98,4 @@
   ansible.builtin.get_url:
     url: http://localhost:8080/api/admin/index
     dest: /tmp/index_status.out
-  when: not upgrade_only
+  when: not dataverse.deployment.upgrade_only

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -248,6 +248,8 @@ dataverse:
     argument: '-DcompilerArgument=-Xlint:unchecked test -P all-unit-tests'
   usermgmtkey: burrito
   version: '5.13'
+  deployment:
+    upgrade_only: false
 
 build_guides: false
 

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -251,6 +251,8 @@ dataverse:
     argument: '-DcompilerArgument=-Xlint:unchecked test -P all-unit-tests'
   usermgmtkey: burrito
   version: '5.13'
+  deployment:
+    upgrade_only: false
 
 build_guides: false
 

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -253,6 +253,8 @@ dataverse:
     argument: '-DcompilerArgument=-Xlint:unchecked test -P all-unit-tests'
   usermgmtkey: burrito
   version: '5.13'
+  deployment:
+    upgrade_only: false
 
 build_guides: false
 


### PR DESCRIPTION
allow for quick upgrade for dataverse war, with fewer side effects

 - introduce dataverse.deployment.upgrade_only variable, false by default
   - if it is false, everything goes on as before
   - if it is set to true, the install script is not called, and a payara redeploy is called instead