### PR TITLE
orcid configuration support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -410,6 +410,11 @@ shibboleth:
   SSO: "<SSO>SAML2 SAML1</SSO>"
   MetadataProvider: '<MetadataProvider type="XML" file="dataverse-idp-metadata.xml" backingFilePath="local-idp-metadata.xml" legacyOrgNames="true" reloadInterval="7200"/>'
 
+orcid:
+  enabled: false
+  clientId: SETME
+  clientSecret: SETME
+
 sshkeys:
   enabled: false
   files:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,6 +113,11 @@
   tags:
   - shibboleth
 
+- ansible.builtin.import_tasks: orcid.yml
+  when: orcid.enabled == "true"
+  tags:
+  - orcid
+
 - ansible.builtin.import_tasks: sampledata.yml
   when: dataverse.sampledata.enabled == true
   tags:

--- a/tasks/orcid.yml
+++ b/tasks/orcid.yml
@@ -1,0 +1,16 @@
+
+- name: create orcid.json
+  template:
+    src: orcid.json.j2
+    dest: /opt/dv/orcid.json
+  register: orcid_json
+
+- name: configure orcid login
+  uri:
+    url: "{{ dataverse.api.location }}/admin/authenticationProviders"
+    method: POST
+    src: /opt/dv/orcid.json
+    remote_src: true
+    body_format: json
+    status_code: 201
+  when: orcid_json.changed

--- a/templates/orcid.json.j2
+++ b/templates/orcid.json.j2
@@ -1,0 +1,8 @@
+{
+  "id":"orcid",
+  "factoryAlias":"oauth2",
+  "title":"ORCID",
+  "subtitle":"",
+  "factoryData":"type: orcid | userEndpoint: https://pub.orcid.org/v2.1/{ORCID}/person | clientId: {{ orcid.clientId }} | clientSecret: {{ orcid.clientSecret }}",
+  "enabled":{{ orcid.enabled }}
+}


### PR DESCRIPTION
Configures orcid after installation.
The code is only called if `orcid.enabled: "true"` (it is false by default).