### PR TITLE
Dataverse raw repo address

### DIFF
--- a/tasks/custom_metadata_blocks.yml
+++ b/tasks/custom_metadata_blocks.yml
@@ -39,14 +39,14 @@
 
 - name: "release case: get develop update-fields.sh from develop"
   ansible.builtin.get_url:
-    url: 'https://raw.githubusercontent.com/IQSS/dataverse/develop/conf/solr/{{ dataverse.solr.version }}/update-fields.sh'
+    url: '{{ dataverse_raw_repo }}/develop/conf/solr/{{ dataverse.solr.version }}/update-fields.sh'
     dest: /tmp/dvinstall/update-fields.sh
     mode: 0755
   when: dataverse_branch == 'release'
 
 - name: "branch case: get develop update-fields.sh from branch"
   ansible.builtin.get_url:
-    url: 'https://raw.githubusercontent.com/IQSS/dataverse/{{ dataverse_branch }}/conf/solr/{{ dataverse.solr.version }}/update-fields.sh'
+    url: '{{ dataverse_raw_repo }}/{{ dataverse_branch }}/conf/solr/{{ dataverse.solr.version }}/update-fields.sh'
     dest: /tmp/dvinstall/update-fields.sh
     mode: 0755
   when: dataverse_branch != 'release'

--- a/tasks/custom_sampledata.yml
+++ b/tasks/custom_sampledata.yml
@@ -20,7 +20,7 @@
 
 - name: get dv-root.json
   get_url:
-    url: 'https://raw.githubusercontent.com/IQSS/dataverse/develop/scripts/api/data/dv-root.json'
+    url: '{{ dataverse_raw_repo }}/develop/scripts/api/data/dv-root.json'
     dest: "{{ playbook_dir }}/"
 
 - name: grant authusers add-on-root

--- a/tasks/dataverse-required-variables.yml
+++ b/tasks/dataverse-required-variables.yml
@@ -5,3 +5,10 @@
 - name: construct payara_dir
   set_fact:
     payara_dir: '{{ dataverse.payara.root }}/{{ dataverse.payara.dir }}'
+
+- name: construct dataverse_raw_repo (githubusercontent) URL
+  set_fact:
+    dataverse_raw_repo: "{{ dataverse_repo | replace('https://github.com/','https://raw.githubusercontent.com/') | regex_replace('.git$','') }}"
+
+#- fail:
+#    msg: "{{ dataverse_raw_repo }}"

--- a/tasks/postgresql_perl_party.yml
+++ b/tasks/postgresql_perl_party.yml
@@ -12,8 +12,8 @@
     dest: '/var/lib/pgsql/{{ db.postgres.version }}/data/log/'
     mode: '0755'
   loop:
-    - https://raw.githubusercontent.com/IQSS/dataverse/develop/scripts/database/querycount/parse.pl
-    - https://raw.githubusercontent.com/IQSS/dataverse/develop/scripts/database/querycount/count.pl
+    - "{{ dataverse_raw_repo }}/develop/scripts/database/querycount/parse.pl"
+    - "{{ dataverse_raw_repo }}/develop/scripts/database/querycount/count.pl"
 
 - name: get name of Postgres logfile
   ansible.builtin.find:


### PR DESCRIPTION
Dataverse's raw repo address is hardcoded in some tasks, which is bad if you deploy a fork of dataverse. This PR automatically calculates the raw repo address from the user-defined `dataverse_repo` variable.