### PR TITLE
configurable robots.txt in dataverse payara deployment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -257,6 +257,7 @@ dataverse:
     argument: '-DcompilerArgument=-Xlint:unchecked test -P all-unit-tests'
   usermgmtkey: burrito
   version: '5.13'
+#  robots_txt_url: https://guides.dataverse.org/en/latest/_downloads/3a5cd7a283eecd5e93289e30af713554/robots.txt
 
 build_guides: false
 

--- a/tasks/dataverse-optional-settings.yml
+++ b/tasks/dataverse-optional-settings.yml
@@ -35,3 +35,9 @@
   shell: '{{ payara_dir}}/bin/asadmin create-jvm-options "-Ddataverse.oai.server.maxrecords={{ harvest.oaiserver.maxrecords }}"'
   when: harvest.oaiserver.maxrecords is defined
 
+- name: overwrite robots.txt in dataverse installation using the file defined by dataverse.robots_txt_url
+  get_url:
+    url: '{{ dataverse.robots_txt_url }}'
+    dest: '{{ payara_dir }}/glassfish/domains/{{ dataverse.payara.domain }}/applications/dataverse/robots.txt'
+    force: true
+  when: dataverse.robots_txt_url is defined


### PR DESCRIPTION
you can define dataverse.robots_txt_url which overwrites robots.txt in the dataverse payara deployment