### PR TITLE
option to add custom certificate authorities

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -416,3 +416,11 @@ sshkeys:
   urls:
   user:
 
+extra_certificates:
+  # this should be a list of certificate files in x509 format put in your files/ ansible directory
+  files: []
+  java_keystores:
+    - path: '{{ payara_dir }}/glassfish/domains/{{ dataverse.payara.domain }}/config/cacerts.jks'
+      pass: changeit
+    - path: '{{ java.home }}/lib/security/cacerts'
+      pass: changeit

--- a/tasks/extra-certificate-authorities.yml
+++ b/tasks/extra-certificate-authorities.yml
@@ -1,0 +1,32 @@
+---
+
+- name: begin certificate authority update task
+  debug:
+    msg: '##### CERTIFICATE AUTHORITIES #####'
+
+- name: create directory to copy certificates to
+  file:
+    path: /opt/certs
+    state: directory
+
+- name: copy extra certificate authorities
+  copy:
+    src: '{{ item }}'
+    dest: /opt/certs/{{ item }}
+  with_items: '{{ extra_certificates.files }}'
+  register: certfiles
+
+- name: add certificates to java keystores
+  community.general.java_cert:
+    cert_path: /opt/certs/{{ item.0 }}
+    keystore_path: '{{ item.1.path }}'
+    cert_alias: '{{ item.0 }}'
+    keystore_pass: '{{ item.1.pass }}'
+    state: present
+  when: certfiles.changed
+  loop: "{{ extra_certificates.files | product(extra_certificates.java_keystores) | list }}"
+  notify: enable and restart payara
+
+## TODO: we may want to add certificate to other keystores later
+## e.g.
+## * system keystore for debian (/etc/ssl/certs) or redhat (?)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,7 +72,10 @@
   - payara
 
 - ansible.builtin.import_tasks: tasks/extra-certificate-authorities.yml
-  when: extra_certificates.files
+  when:
+   - extra_certificates is defined
+   - extra_certificates.files is defined
+   - extra_certificates.files
   tags:
    - extracerts
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,11 @@
   tags:
   - payara
 
+- ansible.builtin.import_tasks: tasks/extra-certificate-authorities.yml
+  when: extra_certificates.files
+  tags:
+   - extracerts
+
 - ansible.builtin.import_tasks: solr.yml
   tags:
   - solr


### PR DESCRIPTION
Option to add custom certificate authorities to e.g. access an S3 API with self-signed certificates
If extra_certificates.files is empty (default), or undefined, it does nothing.