### PR TITLE
Make Solr download url configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -248,6 +248,7 @@ dataverse:
     root: /usr/local/solr
     user: solr
     version: 8.11.1
+    # download_url: # override the default download URL
     checksum: sha256:9ec540cbd8e45f3d15a6b615a22939f5e6242ca81099951a47d3c082c79866a9
     listen: 127.0.0.1
   srcdir: /tmp/dataverse

--- a/tasks/solr.yml
+++ b/tasks/solr.yml
@@ -24,9 +24,19 @@
         createhome=no comment="Dataverse Solr user"
   when: dataverse.solr.user != "root"
 
+- name: Set default solr download url
+  set_fact:
+    solr_download_url: "https://archive.apache.org/dist/lucene/solr/{{ dataverse.solr.version }}/solr-{{ dataverse.solr.version }}.tgz"
+  when: dataverse.solr.download_url is not defined
+
+- name: Set custom solr download url
+  set_fact:
+    solr_download_url: "{{ dataverse.solr.download_url }}"
+  when: dataverse.solr.download_url is defined
+
 - name: download and unzip solr
   get_url:
-    url: "https://archive.apache.org/dist/lucene/solr/{{ dataverse.solr.version }}/solr-{{ dataverse.solr.version }}.tgz"
+    url: "{{ solr_download_url }}"
     checksum: "{{ dataverse.solr.checksum }}"
     dest: /tmp/solr-{{ dataverse.solr.version }}.tgz
   register: solr_installer_download


### PR DESCRIPTION
Makes it possible to specifiy a mirror to download the Solr package from. The official URL sometimes takes forever to download.

The alternative url can be configured via `download_url`, e.g.,

```yaml

  solr:
    group: solr
    root: /usr/local/solr
    user: solr
    version: 8.11.1
    download_url: 'https://some-mirror/solr.tgz'
    checksum: sha256:9ec540cbd8e45f3d15a6b615a22939f5e6242ca81099951a47d3c082c79866a9
    listen: 127.0.0.1
``` 

If download_url is omitted or commented out, the URL is constructed a usual.
