### PR TITLE
fix apache.block.destroy protection to include internal id based deletes

### DIFF
--- a/templates/http.proxy.conf.j2
+++ b/templates/http.proxy.conf.j2
@@ -107,8 +107,8 @@ Listen {{ apache.ssl.port }} https
 
 {% if apache.block.destroy == true %}
   # restrict destroy endpoint to localhost
-  ProxyPassMatch /api/datasets/:persistentId/destroy !
-  RedirectMatch ^/api/datasets/:persistentId/destroy(.*) /
+  ProxyPassMatch /api/datasets/[^/]*/destroy !
+  RedirectMatch ^/api/datasets/[^/]*/destroy(.*) /
 {% endif %}
 
 {% if apache.block.sword == true %}


### PR DESCRIPTION
We talked about this on the mailing list: https://groups.google.com/g/dataverse-community/c/vLPKKEE3mS4/m/JG6UgcHXAAAJ