### PR TITLE
ensure target directory exists before test suite

### DIFF
--- a/tasks/dataverse-api-testsuite.yml
+++ b/tasks/dataverse-api-testsuite.yml
@@ -36,6 +36,14 @@
 - name: ensure we have api script data directory
   shell: "/bin/cp -r {{ dataverse.srcdir }}/scripts/api/data /tmp/dvinstall/"
 
+- name: ensure we have a target when not in a branch
+  ansible.builtin.file:
+    path: '{{ dataverse.srcdir }}/target'
+    owner: '{{ dataverse.payara.user }}'
+    group: '{{ dataverse.payara.group }}'
+    state: directory
+    mode: '0755'
+
 - name: set user management quesadilla
   uri:
     url: 'http://localhost:8080/api/admin/settings/BuiltinUsers.KEY'


### PR DESCRIPTION
Closes #373 

@pdurbin when we deploy a release warfile, we grab the source separately for integration tests (no maven build). things used to work, but this morning maven couldn't create `target/classes/` without `target/` being present, so we ensure that it is.