### PR TITLE
DD-1651: m4a files are not recognized as mpeg/audio by Dataverse

### DIFF
--- a/files/dataverse-previewers.sh
+++ b/files/dataverse-previewers.sh
@@ -144,6 +144,27 @@ curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin
         {"locale":"{localeCode}"}
       ]
     },
+  "contentType":"audio/x-m4a"
+}'
+
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \
+'{
+  "displayName":"Play Audio",
+  "description":"Listen to an audio file.",
+  "toolName":"audioPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://gdcc.github.io/dataverse-previewers/previewers/v1.2/AudioPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
   "contentType":"audio/ogg"
 }'
 

--- a/files/dataverse-previewers.sh
+++ b/files/dataverse-previewers.sh
@@ -123,6 +123,27 @@ curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin
         {"locale":"{localeCode}"}
       ]
     },
+  "contentType":"audio/mp4"
+}'
+
+curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \
+'{
+  "displayName":"Play Audio",
+  "description":"Listen to an audio file.",
+  "toolName":"audioPreviewer",
+  "scope":"file",
+  "types":["preview"],
+  "toolUrl":"https://gdcc.github.io/dataverse-previewers/previewers/v1.2/AudioPreview.html",
+  "toolParameters": {
+      "queryParameters":[
+        {"fileid":"{fileId}"},
+        {"siteUrl":"{siteUrl}"},
+        {"key":"{apiToken}"},
+        {"datasetid":"{datasetId}"},
+        {"datasetversion":"{datasetVersion}"},
+        {"locale":"{localeCode}"}
+      ]
+    },
   "contentType":"audio/ogg"
 }'
 


### PR DESCRIPTION
how to test
--------------

    start-preprovisioned-box.py -s

upload files to a dataset: sample3 from
https://toolsfairy.com/tools/audio-test/sample-mp3-files# and 
https://toolsfairy.com/tools/audio-test/sample-m4a-files#

save the dataset changes, only the mp3 will have a previewer

execute the curl command, revisit the dataset/file page, both files will have a previewer on both files