### PR TITLE
Certbot for Debian and letsencrypt staging

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,10 @@ letsencrypt:
     autorenew: true
     email:
     user: certbot
+    # Use the letsencrypt staging server for deployment tests
+    # to avoid rate limiting:
+    # https://letsencrypt.org/docs/duplicate-certificate-limit/
+    test_cert: false
 
 dataverse_misc_files_dir: '/opt/dv'
 

--- a/tasks/certbot.yml
+++ b/tasks/certbot.yml
@@ -9,7 +9,7 @@
     name: '{{ letsencrypt.certbot.user }}'
 
 - name: install certbot package
-  yum:
+  package:
     name:
       - certbot
       - python3-certbot-apache
@@ -24,7 +24,9 @@
   service:
     name: httpd
     state: stopped
-  when: not letsencrypt_cert.stat.exists
+  when:
+    - ansible_os_family == "RedHat"
+    - not letsencrypt_cert.stat.exists
 
 - name: Generate new certificate if one doesn't exist.
   command: 'certbot --apache --noninteractive --agree-tos --email {{ letsencrypt.certbot.email }} -d {{ servername }}'
@@ -34,11 +36,24 @@
   service:
     name: httpd
     state: started
-  when: not letsencrypt_cert.stat.exists
+  when:
+    - ansible_os_family == "RedHat"
+    - not letsencrypt_cert.stat.exists
 
-- name: automatically renew certs
+- name: automatically renew certs on rocky
   service:
     name: certbot-renew.timer
     state: started
-    enabled: yes
-  when: letsencrpyt.certbot.autonew == true
+    enabled: true
+  when:
+    - letsencrypt.certbot.autorenew == true
+    - ansible_os_family == "RedHat"
+
+- name: automatically renew certs on debian
+  service:
+    name: certbot
+    state: started
+    enabled: true
+  when:
+    - letsencrypt.certbot.autorenew == true
+    - ansible_os_family == "Debian"

--- a/tasks/certbot.yml
+++ b/tasks/certbot.yml
@@ -1,27 +1,27 @@
 ---
 
-- name: begin certbot task
-  debug:
+- name: Begin certbot task
+  ansible.builtin.debug:
     msg: '##### CERTBOT #####'
 
-- name: create certbot user
-  user:
+- name: Create certbot user
+  ansible.builtin.user:
     name: '{{ letsencrypt.certbot.user }}'
 
-- name: install certbot package
-  package:
+- name: Install certbot package
+  ansible.builtin.package:
     name:
       - certbot
       - python3-certbot-apache
     state: latest
 
-- name: check if certificate already exists
-  stat:
+- name: Check if certificate already exists
+  ansible.builtin.stat:
     path: /etc/letsencrypt/live/{{ servername }}/cert.pem
   register: letsencrypt_cert
 
-- name: stop services to allow certbot to generate a cert
-  service:
+- name: Stop services to allow certbot to generate a cert
+  ansible.builtin.service:
     name: httpd
     state: stopped
   when:
@@ -29,19 +29,19 @@
     - not letsencrypt_cert.stat.exists
 
 - name: Generate new certificate if one doesn't exist.
-  command: 'certbot --apache --noninteractive --agree-tos --email {{ letsencrypt.certbot.email }} -d {{ servername }} {{ "--test-cert" if letsencrypt.certbot.test_cert else "" }}'
+  ansible.builtin.command: 'certbot --apache --noninteractive --agree-tos --email {{ letsencrypt.certbot.email }} -d {{ servername }} {{ "--test-cert" if letsencrypt.certbot.test_cert else "" }}'
   when: not letsencrypt_cert.stat.exists
 
-- name: start services after cert has been generated
-  service:
+- name: Start services after cert has been generated
+  ansible.builtin.service:
     name: httpd
     state: started
   when:
     - ansible_os_family == "RedHat"
     - not letsencrypt_cert.stat.exists
 
-- name: automatically renew certs on rocky
-  service:
+- name: Automatically renew certs on rocky
+  ansible.builtin.service:
     name: certbot-renew.timer
     state: started
     enabled: true
@@ -49,8 +49,8 @@
     - letsencrypt.certbot.autorenew == true
     - ansible_os_family == "RedHat"
 
-- name: automatically renew certs on debian
-  service:
+- name: Automatically renew certs on debian
+  ansible.builtin.service:
     name: certbot
     state: started
     enabled: true

--- a/tasks/certbot.yml
+++ b/tasks/certbot.yml
@@ -29,7 +29,7 @@
     - not letsencrypt_cert.stat.exists
 
 - name: Generate new certificate if one doesn't exist.
-  command: 'certbot --apache --noninteractive --agree-tos --email {{ letsencrypt.certbot.email }} -d {{ servername }}'
+  command: 'certbot --apache --noninteractive --agree-tos --email {{ letsencrypt.certbot.email }} -d {{ servername }} {{ "--test-cert" if letsencrypt.certbot.test_cert else "" }}'
   when: not letsencrypt_cert.stat.exists
 
 - name: start services after cert has been generated


### PR DESCRIPTION
This PR adds support for certbot with auto-renewal on Debian systems. Mainly this entails switching from using `yum` to `package`. In out setup, stopping apache was not required for certificate renewal.

Additionally, it adds a parameter to use the letsencrypt staging servers. When testing (and debugging) deployment with a new Dataverse version, I ran into rate limiting by letsencrypt. For deployment tests etc., [letsencrypt suggest](https://letsencrypt.org/docs/duplicate-certificate-limit/) using the staging server. Per default, this is set to false and can be activated through a host variable. 

Finally, this PR applies some minor changes suggested by ansible-lint.