### PR TITLE
modify create instance to clean up keypairs

### DIFF
--- a/ec2/ec2-create-instance.sh
+++ b/ec2/ec2-create-instance.sh
@@ -289,9 +289,9 @@ if [ -z "$DESTROY" ]; then
 else
    echo "destroying AWS instance"
    eval $DESTROY_CMD
+   if [ -z "$PEM_PATH" ]; then
+        aws $PROFILE ec2 delete-key-pair --key-name $KEY_NAME
+      fi
    echo "removing EC2 PEM"
    rm -f $PEM_FILE
-   if [ -z "$PEM_PATH" ]; then
-     aws $PROFILE ec2 delete-key-pair --key-name $KEY_NAME
-   fi
 fi

--- a/ec2/ec2-create-instance.sh
+++ b/ec2/ec2-create-instance.sh
@@ -283,9 +283,15 @@ if [ -z "$DESTROY" ]; then
    echo "ssh -i $PEM_FILE $USER_AT_HOST"
    echo "When you are done, please terminate your instance with:"
    echo "$DESTROY_CMD"
+   if [ -z "$PEM_PATH" ]; then
+       echo "aws $PROFILE ec2 delete-key-pair --key-name $KEY_NAME"
+    fi
 else
    echo "destroying AWS instance"
    eval $DESTROY_CMD
    echo "removing EC2 PEM"
    rm -f $PEM_FILE
+   if [ -z "$PEM_PATH" ]; then
+     aws $PROFILE ec2 delete-key-pair --key-name $KEY_NAME
+   fi
 fi


### PR DESCRIPTION
Added KeyPair deletion when KeyPair is created (no pem file padded in) and -d (destroy) is passed
Added command to be shown to the user if the destroy option is not selected.

Closes:#381