### PR TITLE
Use branding path variable

### DIFF
--- a/tasks/dataverse-gui.yml
+++ b/tasks/dataverse-gui.yml
@@ -23,7 +23,7 @@
 
 - name: copy branding files
   copy:
-    src: branding
+    src: '{{ dataverse.branding.directory }}'
     dest: '{{ gui_file_path }}'
     owner: '{{ dataverse.payara.user }}'
     group: '{{ dataverse.payara.group }}'

--- a/tasks/dataverse-gui.yml
+++ b/tasks/dataverse-gui.yml
@@ -3,7 +3,7 @@
 # dataverse/tasks/dataverse-gui.yml
 # install gui modifications (branding and favicons), if defined
 
-- name: calculate destination directories
+- name: Calculate destination directories
   set_fact:
     gui_file_path: '{{ payara_dir }}/glassfish/domains/{{ dataverse.payara.domain }}/applications/dataverse'
     favicon_file_path: '{{ payara_dir }}/glassfish/domains/{{ dataverse.payara.domain }}/applications/dataverse/resources/images/fav/'
@@ -21,7 +21,7 @@
     group: '{{ dataverse.payara.group }}'
   with_fileglob: '{{ dataverse.branding.favicons_directory }}/*.ico'
 
-- name: copy branding files
+- name: Copy branding files
   copy:
     src: '{{ dataverse.branding.directory }}'
     dest: '{{ gui_file_path }}'


### PR DESCRIPTION
This PR uses the variable `dataverse.branding.directory` defined in [`defaults/main.yml`](https://github.com/gdcc/dataverse-ansible/blob/1e6a6f169010bf3edb16f7e8c8883f31518961aa/defaults/main.yml#L65) to determine the branding file folder instead of the hardcoded branding  directory (`files/branding`). The default behavior should remain identical.