### PR TITLE
Have Payara Default to Localhost

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -211,6 +211,7 @@ dataverse:
     adminuser: admin
     adminpass: notPr0d
     siteurl:
+    listen_address: 127.0.0.1
     launch_timeout: 180
     request_timeout: 1800
     root: /usr/local

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -27,6 +27,11 @@
   become_user: "{{ dataverse.payara.user }}"
   shell: "{{ payara_dir }}/bin/asadmin set-log-levels org.glassfish.grizzly.http.server.util.RequestUtils=SEVERE"
 
+- name: set payara to default to localhost
+  become: yes
+  become_user: "{{ dataverse.payara.user }}"
+  shell: "{{ payara_dir }}/bin/asadmin set server-config.network-config.network-listeners.network-listener.http-listener-1.address={{ payara.listen_address }}"
+
 - name: override some default settings
   become: yes
   become_user: "{{ dataverse.payara.user }}"

--- a/tasks/dataverse-postinstall.yml
+++ b/tasks/dataverse-postinstall.yml
@@ -30,7 +30,7 @@
 - name: set payara to default to localhost
   become: yes
   become_user: "{{ dataverse.payara.user }}"
-  shell: "{{ payara_dir }}/bin/asadmin set server-config.network-config.network-listeners.network-listener.http-listener-1.address={{ payara.listen_address }}"
+  shell: "{{ payara_dir }}/bin/asadmin set server-config.network-config.network-listeners.network-listener.http-listener-1.address={{ dataverse.payara.listen_address }}"
 
 - name: override some default settings
   become: yes

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -148,6 +148,7 @@ dataverse:
     launch_timeout: 180
     request_timeout: 1800
     siteurl: 
+    listen_address: 127.0.0.1
     root: /usr/local
     dir: payara6
     zipurl: https://nexus.payara.fish/repository/payara-community/fish/payara/distributions/payara/6.2025.3/payara-6.2025.3.zip

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -153,6 +153,7 @@ dataverse:
     launch_timeout: 180
     request_timeout: 1800
     siteurl: http://0.0.0.0
+    listen_address: 127.0.0.1
     root: /usr/local
     dir: payara6
     zipurl: https://nexus.payara.fish/repository/payara-community/fish/payara/distributions/payara/6.2025.3/payara-6.2025.3.zip


### PR DESCRIPTION
As suggested to me by @donsizemore, it will be wise to configure Payara to listen from localhost only. I've placed this configuration in `tasks/dataverse-postinstall.yml` and added `dataverse.payara.listen_address` in a few obvious locations.

- Closes #403