### PR TITLE
bump maven to a version that's available on ibiblio

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -348,7 +348,7 @@ localstack:
       chunked_encoding: true
 
 maven:
-  version: 3.9.11
+  version: 3.9.12
 
 minio:
   enabled: false

--- a/tests/group_vars/11639-db-opts-idempotency.yml
+++ b/tests/group_vars/11639-db-opts-idempotency.yml
@@ -339,7 +339,7 @@ localstack:
       chunked_encoding: true
 
 maven:
-  version: 3.9.11
+  version: 3.9.12
 
 minio:
   enabled: true

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -339,7 +339,7 @@ localstack:
       chunked_encoding: true
 
 maven:
-  version: 3.9.11
+  version: 3.9.12
 
 minio:
   enabled: true

--- a/tests/group_vars/memorytests.yml
+++ b/tests/group_vars/memorytests.yml
@@ -311,7 +311,7 @@ localstack:
   web_ui: 8888
 
 maven:
-  version: 3.9.11
+  version: 3.9.12
 
 munin:
   install: false

--- a/tests/group_vars/payara_6.2025.10.yml
+++ b/tests/group_vars/payara_6.2025.10.yml
@@ -339,7 +339,7 @@ localstack:
       chunked_encoding: true
 
 maven:
-  version: 3.9.11
+  version: 3.9.12
 
 minio:
   enabled: true

--- a/tests/group_vars/vagrant.yml
+++ b/tests/group_vars/vagrant.yml
@@ -347,7 +347,7 @@ localstack:
       chunked_encoding: true
 
 maven:
-  version: 3.9.11
+  version: 3.9.12
 
 minio:
   enabled: false


### PR DESCRIPTION
- Closes #414

Please note that I only bumped the version in the recent files. Maybe the others should be deleted some day? Here's a list:

```
% ack 'maven:' tests/group_vars -A1
tests/group_vars/vagrant.yml
349:maven:
350-  version: 3.9.12

tests/group_vars/jenkins.yml
341:maven:
342-  version: 3.9.12

tests/group_vars/java17.yml
307:maven:
308-  version: 3.8.8

tests/group_vars/postgres15.yml
306:maven:
307-  version: 3.8.8

tests/group_vars/payara_6.2025.10.yml
341:maven:
342-  version: 3.9.12

tests/group_vars/solr9_9260-vanilla-solr-src.yml
306:maven:
307-  version: 3.8.8

tests/group_vars/memorytests.yml
313:maven:
314-  version: 3.9.12

tests/group_vars/11639-db-opts-idempotency.yml
341:maven:
342-  version: 3.9.12

tests/group_vars/solr9.yml
308:maven:
309-  version: 3.8.8

tests/group_vars/solr_9.8.0.yml
339:maven:
340-  version: 3.9.5

tests/group_vars/payara_6.2025.2.yml
339:maven:
340-  version: 3.9.5

tests/group_vars/solr_9.8.1.yml
339:maven:
340-  version: 3.9.5
```