### PR TITLE
prevent 404 by bumping version of maven used to 3.9.14

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -348,7 +348,7 @@ localstack:
       chunked_encoding: true
 
 maven:
-  version: 3.9.13
+  version: 3.9.14
 
 minio:
   enabled: false

--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -339,7 +339,7 @@ localstack:
       chunked_encoding: true
 
 maven:
-  version: 3.9.13
+  version: 3.9.14
 
 minio:
   enabled: true

--- a/tests/group_vars/payara_7.2026.1.yml
+++ b/tests/group_vars/payara_7.2026.1.yml
@@ -339,7 +339,7 @@ localstack:
       chunked_encoding: true
 
 maven:
-  version: 3.9.13
+  version: 3.9.14
 
 minio:
   enabled: true


### PR DESCRIPTION
- Closes #419 

This PR is modeled off 356db19, which fixed the following issu:

- #418

I haven't tested it so please take a good look!