### PR TITLE
Update Jenkins version from 6.9 to 6.10

### DIFF
--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -260,7 +260,7 @@ dataverse:
   usermgmtkey: burrito
   deployment:
     upgrade_only: false
-  version: '6.9'
+  version: '6.10'
 
 build_guides: false
 


### PR DESCRIPTION
Here's the related issue to bump the backend:

- https://github.com/IQSS/dataverse/issues/12091

I'm keeping this PR in draft until we're ready.