### PR TITLE
#422 bump localstack to 4.2

### DIFF
--- a/templates/localstack-compose.yml.j2
+++ b/templates/localstack-compose.yml.j2
@@ -1,22 +1,16 @@
-version: '2.1'
+version: '4.2'
 
 services:
   localstack:
     container_name: "{{ localstack.container_name }}"
-    image: localstack/localstack
+    image: localstack/localstack:4.2
     ports:
       - "127.0.0.1:4566:4566"
-      #- "4567-4599:4567-4599"
-      #- "{{ localstack.web_ui }}-{{ localstack.web_ui }}:{{ localstack.web_ui }}-{{ localstack.web_ui }}"
     environment:
-      - SERVICES=s3
       - DEBUG={{ localstack.debug }}
-      #- DATA_DIR={{ localstack.data_dir }}
-      #- PORT_WEB_UI={{ localstack.web_ui }}
-      - LOCALSTACK_HOSTNAME={{ localstack.hostname_external }}
-      #- LAMBDA_EXECUTOR=local
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
+      - "./localstack-data:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
     tmpfs:
       - /localstack:mode=770,size=128M,uid=1000,gid=1000


### PR DESCRIPTION
Closes #422 

Localstack wouldn't start because the version being used was outdated. Bumped it to 4.2, and made related configuration changes.

EC2 tests pass when launched locally.