### PR TITLE
feat(jenkins): add localstack_noredirect bucket to localstack config

### DIFF
--- a/tests/group_vars/jenkins.yml
+++ b/tests/group_vars/jenkins.yml
@@ -337,6 +337,25 @@ localstack:
       url_expiration_minutes: 60
       payload_signing: false
       chunked_encoding: true
+    # localstack_noredirect: same bucket/endpoint as localstack1 but with
+    # both redirects disabled, so tests can exercise the non-redirect
+    # (proxy-through-Dataverse) code path explicitly.
+    - label: LocalStackNoRedirect
+      id: localstack_noredirect
+      bucket_name: mybucket
+      enabled: false
+      access_key: 4cc355_k3y
+      secret_access_key: s3cr3t_4cc355_k3y
+      custom_endpoint_url: "http://localhost:4566"
+      download_redirect: false
+      upload_redirect: false
+      files_type: s3
+      ingestsizelimit: 2000000000
+      path_style_access: true
+      region: us-east-2
+      url_expiration_minutes: 60
+      payload_signing: false
+      chunked_encoding: true
 
 maven:
   version: 3.9.15


### PR DESCRIPTION
Since we are removing LocalStack from Dataverse, we added a localstack provider named localstack_noredirect for the tests. This PR simply adds the provider, doesn't remove anything.